### PR TITLE
feat: s3에 사진 저장,삭제 서비스 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'mysql:mysql-connector-java:8.0.33'

--- a/src/main/java/com/devonoff/config/S3Config.java
+++ b/src/main/java/com/devonoff/config/S3Config.java
@@ -1,0 +1,4 @@
+package com.devonoff.config;
+
+public class S3Config {
+}

--- a/src/main/java/com/devonoff/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/devonoff/domain/photo/service/PhotoService.java
@@ -1,0 +1,4 @@
+package com.devonoff.domain.photo.service;
+
+public class PhotoService {
+}


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> 
> 🔖 **TO-BE**
> 유저 프로필 사진, 게시글 썸네일 이미지를 s3에 업로드한 후 imgUrl을 반환해주고, imgUrl을 전달해주면 s3에서 삭제도 할 수 있는 서비스를 구현했습니다.
> 다음의 코드들을 application.properties에 추가하시면 사용하실 수 있습니다.
```
cloud.aws.s3.bucket=<s3버킷>
cloud.aws.credentials.accessKey=<s3 사용자 엑세스키>
cloud.aws.credentials.secretKey=<s3 사용자 비밀키>
cloud.aws.region.static=<s3 위치>
```
> s3 내부에서는 유저ID마다 폴더가 생성되어 사진 이름 그대로 저장되게 되고 같은 이름을 가진 사진이 존재할 경우 저장되지 > 않습니다. 이에 대해 의견있으시면 편하게 주시면 감사하겠습니다.
> 또 실제 imgUrl을 확인하기 위해서는 s3버킷에 public 처리를 하셔야 합니다.

> ### 테스트
> - [X] API 테스트 : 임의의 컨트롤러를 만들어 postman으로 사진 저장,삭제 기능을 모두 확인하였습니다.