### PR TITLE
feat: s3 관련 사진 저장,삭제 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'mysql:mysql-connector-java:8.0.33'

--- a/src/main/java/com/devonoff/config/S3Config.java
+++ b/src/main/java/com/devonoff/config/S3Config.java
@@ -1,0 +1,4 @@
+package com.devonoff.config;
+
+public class S3Config {
+}

--- a/src/main/java/com/devonoff/config/S3Config.java
+++ b/src/main/java/com/devonoff/config/S3Config.java
@@ -1,4 +1,33 @@
 package com.devonoff.config;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
 public class S3Config {
+
+  @Value("${cloud.aws.credentials.accessKey}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secretKey}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3Client amazonS3Client() {
+    BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,
+        secretKey);
+    return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+        .withRegion(region)
+        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+        .build();
+  }
 }

--- a/src/main/java/com/devonoff/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/devonoff/domain/photo/service/PhotoService.java
@@ -1,4 +1,54 @@
 package com.devonoff.domain.photo.service;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
 public class PhotoService {
+
+  private final AmazonS3Client amazonS3Client;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  private String urlPrefix;
+
+  @PostConstruct
+  public void init() {
+    urlPrefix = "https://" + bucket + "." + region + ".amazonaws.com";
+  }
+
+  public String save(MultipartFile file) {
+    //TODO userId 로그인 유저 확인 후 변경
+    Long userId = 1L;
+    try {
+      String fileName = file.getOriginalFilename();
+      ObjectMetadata metadata = new ObjectMetadata();
+      metadata.setContentType(file.getContentType());
+      metadata.setContentLength(file.getSize());
+      if (amazonS3Client.doesObjectExist(bucket, userId + "/" + fileName)) {
+        throw new ResponseStatusException(HttpStatus.CONFLICT, "File already exists");
+      }
+      this.amazonS3Client.putObject(bucket, userId + "/" + fileName,
+          file.getInputStream(),
+          metadata);
+      return urlPrefix + userId + "/" + fileName;
+    } catch (Exception e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+  }
+
+  public void delete(String fileUrl) {
+    this.amazonS3Client.deleteObject(bucket, fileUrl.substring(urlPrefix.length()));
+  }
 }

--- a/src/main/java/com/devonoff/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/devonoff/domain/photo/service/PhotoService.java
@@ -1,0 +1,4 @@
+package com.devonoff.domain.photo.service;
+
+public class PhotoService {
+}


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> 
> 🔖 **TO-BE**
> 유저 프로필 사진, 게시글 썸네일 이미지를 s3에 업로드한 후 imgUrl을 반환해주고, imgUrl을 전달해주면 s3에서 삭제도 할 수 있는 서비스를 구현했습니다.
> 다음의 코드들을 application.properties에 추가하시면 사용하실 수 있습니다.
```
cloud.aws.s3.bucket=<s3버킷>
cloud.aws.credentials.accessKey=<s3 사용자 엑세스키>
cloud.aws.credentials.secretKey=<s3 사용자 비밀키>
cloud.aws.region.static=<s3 위치>
```
> s3 내부에서는 유저ID마다 폴더가 생성되어 사진 이름 그대로 저장되게 되고 같은 이름을 가진 사진이 존재할 경우 저장되지 > 않습니다. 이에 대해 의견있으시면 편하게 주시면 감사하겠습니다.
> 또 실제 imgUrl을 통해 사진을 확인하기 위해서는 s3버킷에 public 처리를 하셔야 합니다.

> ### 테스트
> - [X] API 테스트 : 임의의 컨트롤러를 만들어 postman으로 사진 저장,삭제 기능을 모두 확인하였습니다.