### PR TITLE
fix/user-nickname-token-bug-fix

### DIFF
--- a/src/main/java/com/devonoff/domain/redis/service/RedisService.java
+++ b/src/main/java/com/devonoff/domain/redis/service/RedisService.java
@@ -38,7 +38,7 @@ public class RedisService {
       throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
     }
 
-    if (refreshTokenData.equals(refreshToken)) {
+    if (!refreshTokenData.equals(refreshToken)) {
       throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
     }
   }

--- a/src/main/java/com/devonoff/domain/user/dto/UserDto.java
+++ b/src/main/java/com/devonoff/domain/user/dto/UserDto.java
@@ -22,7 +22,7 @@ public class UserDto {
   public static UserDto fromEntity(User user) {
     return UserDto.builder()
         .id(user.getId())
-        .nickName(user.getNickName())
+        .nickName(user.getNickname())
         .email(user.getEmail())
         .profileImageUrl(user.getProfileImage())
         .build();

--- a/src/main/java/com/devonoff/domain/user/entity/User.java
+++ b/src/main/java/com/devonoff/domain/user/entity/User.java
@@ -32,7 +32,7 @@ public class User extends BaseTimeEntity implements UserDetails {
   private Long id;
 
   @Column(nullable = false)
-  private String nickName;
+  private String nickname;
 
   @Column(nullable = false)
   private String email;

--- a/src/main/java/com/devonoff/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/devonoff/domain/user/repository/UserRepository.java
@@ -10,7 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
 
-  boolean existsByNickName(String nickName);
+  boolean existsByNickname(String nickName);
 
   boolean existsByEmail(String email);
 

--- a/src/main/java/com/devonoff/domain/user/service/AuthService.java
+++ b/src/main/java/com/devonoff/domain/user/service/AuthService.java
@@ -125,7 +125,7 @@ public class AuthService {
 
     userRepository.save(
         User.builder()
-            .nickName(nickName)
+            .nickname(nickName)
             .email(email)
             .password(encodedPassword)
             .isActive(true)
@@ -224,7 +224,7 @@ public class AuthService {
    * @param nickName
    */
   public void checkExistsNickName(String nickName) {
-    boolean existsByNickName = userRepository.existsByNickName(nickName);
+    boolean existsByNickName = userRepository.existsByNickname(nickName);
     if (existsByNickName) {
       throw new CustomException(ErrorCode.NICKNAME_ALREADY_REGISTERED);
     }


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
>  - access token 재발급 과정에서 redis 에 저장 되어있는 특정 유저의 refresh token 이 유효한지 검증할 때
>    요청으로 들어온 refresh token 값과 redis 에 저장 되어있는 특정 유저의 refresh token 이 다를 경우 발급 처리
>    요청으로 들어온 refresh token 값과 redis 에 저장 되어있는 특정 유저의 refresh token 이 같을 경우 예외 처리
>
> 🔖 **TO-BE**
>  - User Entity 의 nickName 을 nickname 으로 수정 (erd 와 동기화)
>  - access token 재발급 과정에서 redis 에 저장 되어있는 특정 유저의 refresh token 이 유효한지 검증할 때
>    요청으로 들어온 refresh token 값과 redis 에 저장 되어있는 특정 유저의 refresh token 이 같을 경우 발급 처리
>    요청으로 들어온 refresh token 값과 redis 에 저장 되어있는 특정 유저의 refresh token 이 다를 경우 예외 처리
>    하도록 수정

> ### 테스트
>
> - [ ] 테스트 코드
> - [x] API 테스트