### PR TITLE
정보공유 게시판 기능 추가, application.yml 변수명 변경, JpaAuditingConfiguration 분리

### DIFF
--- a/src/main/java/com/devonoff/DevOnOffApplication.java
+++ b/src/main/java/com/devonoff/DevOnOffApplication.java
@@ -2,11 +2,9 @@ package com.devonoff;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class DevOnOffApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/devonoff/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/devonoff/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.devonoff.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfiguration {
+
+}

--- a/src/main/java/com/devonoff/domain/infosharepost/controller/InfoSharePostController.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/controller/InfoSharePostController.java
@@ -1,0 +1,65 @@
+package com.devonoff.domain.infosharepost.controller;
+
+import com.devonoff.domain.infosharepost.dto.InfoSharePostDto;
+import com.devonoff.domain.infosharepost.service.InfoSharePostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/info-posts")
+@RequiredArgsConstructor
+public class InfoSharePostController {
+
+  private final InfoSharePostService infoSharePostService;
+
+  @PostMapping
+  public ResponseEntity<InfoSharePostDto> createInfoSharePost(
+      @RequestBody InfoSharePostDto infoSharePost) {
+    var result = this.infoSharePostService.createInfoSharePost(infoSharePost);
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<InfoSharePostDto>> getInfoSharePosts(@RequestParam Integer page,
+      @RequestParam String search) {
+    var result = this.infoSharePostService.getInfoSharePosts(page, search);
+    return ResponseEntity.ok(result);
+  }
+
+  //TODO userId -> nickname으로 변경해야함, InfoSharePost 테이블에 nickname추가?
+  @GetMapping("/author/{userId}")
+  public ResponseEntity<Page<InfoSharePostDto>> getInfoSharePostsByUserId(@PathVariable Long userId,
+      @RequestParam Integer page, @RequestParam String search) {
+    var result = this.infoSharePostService.getInfoSharePostsByUserId(userId, page, search);
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/{infoPostId}")
+  public ResponseEntity<InfoSharePostDto> getInfoSharePostByPostId(
+      @PathVariable Long infoPostId) {
+    var result = this.infoSharePostService.getInfoSharePostByPostId(infoPostId);
+    return ResponseEntity.ok(result);
+  }
+
+  @PutMapping("/{infoPostId}")
+  public ResponseEntity<InfoSharePostDto> updateInfoSharePost(@PathVariable Long infoPostId,
+      @RequestBody InfoSharePostDto infoSharePostDto) {
+    var result = this.infoSharePostService.updateInfoSharePost(infoPostId, infoSharePostDto);
+    return ResponseEntity.ok(result);
+  }
+
+  @DeleteMapping("/{infoPostId}")
+  public void deleteInfoSharePost(@PathVariable Long infoPostId) {
+    this.infoSharePostService.deleteInfoSharePost(infoPostId);
+  }
+}

--- a/src/main/java/com/devonoff/domain/infosharepost/dto/InfoSharePostDto.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/dto/InfoSharePostDto.java
@@ -1,0 +1,55 @@
+package com.devonoff.domain.infosharepost.dto;
+
+import com.devonoff.domain.infosharepost.entity.InfoSharePost;
+import com.devonoff.domain.user.dto.UserDto;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class InfoSharePostDto {
+
+  private Long id;
+  private Long userId;
+  private String thumbnailImgUrl;
+  private String title;
+  private String description;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private UserDto user;
+
+  public static InfoSharePostDto fromEntity(InfoSharePost post) {
+    return InfoSharePostDto.builder()
+        .id(post.getId())
+        .userId(post.getUserId())
+        .thumbnailImgUrl(post.getThumbnailImgUrl())
+        .title(post.getTitle())
+        .description(post.getDescription())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(post.getUpdatedAt())
+        .build();
+  }
+
+  public static InfoSharePost toEntity(InfoSharePostDto infoSharePostDto) {
+    return InfoSharePost.builder()
+        .userId(infoSharePostDto.getUserId())
+        .thumbnailImgUrl(infoSharePostDto.getThumbnailImgUrl())
+        .title(infoSharePostDto.getTitle())
+        .description(infoSharePostDto.getDescription())
+        .build();
+  }
+
+  public static InfoSharePostDto fromEntityWithUserInfo(InfoSharePost infoSharePost,
+      UserDto userDto) {
+    InfoSharePostDto infoSharePostDto = InfoSharePostDto.fromEntity(infoSharePost);
+    infoSharePostDto.setUser(userDto);
+    return infoSharePostDto;
+  }
+}

--- a/src/main/java/com/devonoff/domain/infosharepost/entity/InfoSharePost.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/entity/InfoSharePost.java
@@ -1,0 +1,42 @@
+package com.devonoff.domain.infosharepost.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class InfoSharePost {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private Long userId;
+  private String thumbnailImgUrl;
+  private String title;
+  @Column(columnDefinition = "TEXT")
+  private String description;
+  @CreatedDate
+  private LocalDateTime createdAt;
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+
+}

--- a/src/main/java/com/devonoff/domain/infosharepost/repository/InfoSharePostRepository.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/repository/InfoSharePostRepository.java
@@ -1,0 +1,14 @@
+package com.devonoff.domain.infosharepost.repository;
+
+import com.devonoff.domain.infosharepost.entity.InfoSharePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InfoSharePostRepository extends JpaRepository<InfoSharePost, Long> {
+
+  Page<InfoSharePost> findAllByTitleContaining(String search, Pageable pageable);
+
+  Page<InfoSharePost> findAllByUserIdAndTitleContaining(Long userId, String search,
+      Pageable pageable);
+}

--- a/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
@@ -1,0 +1,92 @@
+package com.devonoff.domain.infosharepost.service;
+
+import static com.devonoff.type.ErrorCode.POST_NOT_FOUND;
+import static com.devonoff.type.ErrorCode.UNAUTHORIZED_ACCESS;
+import static com.devonoff.type.ErrorCode.USER_NOT_FOUND;
+
+import com.devonoff.domain.infosharepost.dto.InfoSharePostDto;
+import com.devonoff.domain.infosharepost.entity.InfoSharePost;
+import com.devonoff.domain.infosharepost.repository.InfoSharePostRepository;
+import com.devonoff.domain.user.dto.UserDto;
+import com.devonoff.domain.user.entity.User;
+import com.devonoff.domain.user.repository.UserRepository;
+import com.devonoff.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InfoSharePostService {
+
+  private final InfoSharePostRepository infoSharePostRepository;
+  private final UserRepository userRepository;
+
+  public InfoSharePostDto createInfoSharePost(InfoSharePostDto infoSharePostDto) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    infoSharePostDto.setUserId(Long.parseLong(userDetails.getUsername()));
+    return InfoSharePostDto.fromEntity(
+        this.infoSharePostRepository.save(InfoSharePostDto.toEntity(infoSharePostDto)));
+  }
+
+  public Page<InfoSharePostDto> getInfoSharePosts(Integer page, String search) {
+    Pageable pageable = PageRequest.of(page, 10);
+    return this.infoSharePostRepository.findAllByTitleContaining(search,
+            pageable)
+        .map(infoSharePost -> {
+          User user = this.userRepository.findById(infoSharePost.getUserId())
+              .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+          return InfoSharePostDto.fromEntityWithUserInfo(infoSharePost, UserDto.fromEntity(user));
+        });
+  }
+
+  public Page<InfoSharePostDto> getInfoSharePostsByUserId(Long userId, Integer page,
+      String search) {
+    Pageable pageable = PageRequest.of(page, 10);
+    return this.infoSharePostRepository.findAllByUserIdAndTitleContaining(userId, search, pageable)
+        .map(infoSharePost -> {
+          User user = this.userRepository.findById(infoSharePost.getUserId())
+              .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+          return InfoSharePostDto.fromEntityWithUserInfo(infoSharePost, UserDto.fromEntity(user));
+        });
+  }
+
+  public InfoSharePostDto getInfoSharePostByPostId(Long infoPostId) {
+    InfoSharePost infoSharePost = this.infoSharePostRepository.findById(infoPostId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    UserDto userDto = UserDto.fromEntity(this.userRepository.findById(infoSharePost.getUserId())
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND)));
+    return InfoSharePostDto.fromEntityWithUserInfo(infoSharePost, userDto);
+  }
+
+  public InfoSharePostDto updateInfoSharePost(Long infoPostId, InfoSharePostDto infoSharePostDto) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    if (Long.parseLong(userDetails.getUsername()) != infoSharePostDto.getUserId()) {
+      throw new CustomException(UNAUTHORIZED_ACCESS);
+    }
+    InfoSharePost infoSharePost = this.infoSharePostRepository.findById(infoPostId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    infoSharePost.setThumbnailImgUrl(infoSharePostDto.getThumbnailImgUrl());
+    infoSharePost.setTitle(infoSharePostDto.getTitle());
+    infoSharePost.setDescription(infoSharePostDto.getDescription());
+    return InfoSharePostDto.fromEntity(this.infoSharePostRepository.save(infoSharePost));
+  }
+
+  public void deleteInfoSharePost(Long infoPostId) {
+    InfoSharePost infoSharePost = this.infoSharePostRepository.findById(infoPostId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    if (Long.parseLong(userDetails.getUsername()) != infoSharePost.getUserId()) {
+      throw new CustomException(UNAUTHORIZED_ACCESS);
+    }
+    this.infoSharePostRepository.deleteById(infoPostId);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,8 +17,8 @@ spring:
       ddl-auto: update
 
   jwt:
-    secret: ${SECRET_KEY}
-#
+    secret: ${JWT_SECRET_KEY}
+  #
   mail:
     host: smtp.gmail.com
     port: 587
@@ -81,11 +81,11 @@ spring:
 cloud:
   aws:
     s3:
-      bucket: ${AWS_BUCKET_NAME}
+      bucket: ${S3_BUCKET_NAME}
     region:
-      static: ${AWS_REGION}
+      static: ${S3_REGION}
     credentials:
-      accessKey: ${AWS_ACCESS_KEY}
-      secretKey: ${AWS_SECRET_KEY}
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_SECRET_KEY}
     stack:
       auto: false

--- a/src/test/java/com/devonoff/infosharepost/controller/InfoSharePostControllerTest.java
+++ b/src/test/java/com/devonoff/infosharepost/controller/InfoSharePostControllerTest.java
@@ -1,0 +1,157 @@
+package com.devonoff.infosharepost.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devonoff.config.SecurityConfig;
+import com.devonoff.domain.infosharepost.controller.InfoSharePostController;
+import com.devonoff.domain.infosharepost.dto.InfoSharePostDto;
+import com.devonoff.domain.infosharepost.service.InfoSharePostService;
+import com.devonoff.util.JwtAuthenticationFilter;
+import com.devonoff.util.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(InfoSharePostController.class)
+@Import(SecurityConfig.class) // SecurityConfig를 명시적으로 포함 (Optional)
+@AutoConfigureMockMvc(addFilters = false)
+class InfoSharePostControllerTest {
+
+  @MockBean
+  private JwtProvider jwtProvider;
+
+  @MockBean
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @MockBean
+  private InfoSharePostService infoSharePostService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private InfoSharePostDto samplePost;
+
+  @BeforeEach
+  void setUp() {
+    samplePost = new InfoSharePostDto();
+    samplePost.setId(1L);
+    samplePost.setTitle("Sample Title");
+    samplePost.setDescription("Sample Content");
+    samplePost.setUserId(1L);
+  }
+
+  @Test
+  void testCreateInfoSharePost() throws Exception {
+    // given
+    Mockito.when(infoSharePostService.createInfoSharePost(any(InfoSharePostDto.class)))
+        .thenReturn(samplePost);
+
+    // when
+    mockMvc.perform(post("/api/info-posts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(samplePost)))
+
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.title").value("Sample Title"));
+  }
+
+  @Test
+  void testGetInfoSharePosts() throws Exception {
+    // given
+    Page<InfoSharePostDto> page = new PageImpl<>(List.of(samplePost));
+    Mockito.when(infoSharePostService.getInfoSharePosts(anyInt(), anyString()))
+        .thenReturn(page);
+
+    // when
+    mockMvc.perform(get("/api/info-posts")
+            .param("page", "0")
+            .param("search", "Sample"))
+
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").value(1L));
+  }
+
+  @Test
+  void testGetInfoSharePostsByUserId() throws Exception {
+    // given
+    Page<InfoSharePostDto> page = new PageImpl<>(List.of(samplePost));
+    Mockito.when(infoSharePostService.getInfoSharePostsByUserId(anyLong(), anyInt(), anyString()))
+        .thenReturn(page);
+
+    // when
+    mockMvc.perform(get("/api/info-posts/author/1")
+            .param("page", "0")
+            .param("search", "Sample"))
+
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").value(1L));
+  }
+
+  @Test
+  void testGetInfoSharePostByPostId() throws Exception {
+    // given
+    Mockito.when(infoSharePostService.getInfoSharePostByPostId(anyLong()))
+        .thenReturn(samplePost);
+
+    // when
+    mockMvc.perform(get("/api/info-posts/1"))
+
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.title").value("Sample Title"));
+  }
+
+  @Test
+  void testUpdateInfoSharePost() throws Exception {
+    // given
+    Mockito.when(infoSharePostService.updateInfoSharePost(anyLong(), any(InfoSharePostDto.class)))
+        .thenReturn(samplePost);
+
+    // when
+    mockMvc.perform(put("/api/info-posts/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(samplePost)))
+
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.title").value("Sample Title"));
+  }
+
+  @Test
+  void testDeleteInfoSharePost() throws Exception {
+    // when
+    mockMvc.perform(delete("/api/info-posts/1"))
+
+        // then
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/com/devonoff/infosharepost/service/InfoSharePostServiceTest.java
+++ b/src/test/java/com/devonoff/infosharepost/service/InfoSharePostServiceTest.java
@@ -1,0 +1,152 @@
+package com.devonoff.infosharepost.service;
+
+import static com.devonoff.type.ErrorCode.POST_NOT_FOUND;
+import static com.devonoff.type.ErrorCode.UNAUTHORIZED_ACCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.devonoff.domain.infosharepost.dto.InfoSharePostDto;
+import com.devonoff.domain.infosharepost.entity.InfoSharePost;
+import com.devonoff.domain.infosharepost.repository.InfoSharePostRepository;
+import com.devonoff.domain.infosharepost.service.InfoSharePostService;
+import com.devonoff.domain.user.entity.User;
+import com.devonoff.domain.user.repository.UserRepository;
+import com.devonoff.exception.CustomException;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+class InfoSharePostServiceTest {
+
+  @InjectMocks
+  private InfoSharePostService infoSharePostService;
+
+  @Mock
+  private InfoSharePostRepository infoSharePostRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private SecurityContext securityContext;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private UserDetails userDetails;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    SecurityContextHolder.setContext(securityContext);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(userDetails);
+    when(userDetails.getUsername()).thenReturn("1"); // Mocked user ID
+  }
+
+  @Test
+  void createInfoSharePost_success() {
+    // given
+    InfoSharePostDto postDto = new InfoSharePostDto();
+    postDto.setTitle("Test Title");
+    postDto.setDescription("Test Description");
+    postDto.setThumbnailImgUrl("test-url");
+
+    InfoSharePost savedPost = new InfoSharePost();
+    savedPost.setId(1L);
+    savedPost.setTitle("Test Title");
+
+    when(infoSharePostRepository.save(any())).thenReturn(savedPost);
+
+    // when
+    InfoSharePostDto result = infoSharePostService.createInfoSharePost(postDto);
+
+    // then
+    assertThat(result.getTitle()).isEqualTo("Test Title");
+    verify(infoSharePostRepository, times(1)).save(any());
+  }
+
+  @Test
+  void getInfoSharePostByPostId_notFound() {
+    // given
+    when(infoSharePostRepository.findById(1L)).thenReturn(Optional.empty());
+
+    // when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> infoSharePostService.getInfoSharePostByPostId(1L));
+
+    // then
+    assertThat(exception.getErrorCode()).isEqualTo(POST_NOT_FOUND);
+  }
+
+  @Test
+  void updateInfoSharePost_unauthorizedAccess() {
+    // given
+    InfoSharePostDto postDto = new InfoSharePostDto();
+    postDto.setUserId(2L); // Different user ID
+
+    // when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> infoSharePostService.updateInfoSharePost(1L, postDto));
+
+    // then
+    assertThat(exception.getErrorCode()).isEqualTo(UNAUTHORIZED_ACCESS);
+  }
+
+  @Test
+  void deleteInfoSharePost_success() {
+    // given
+    InfoSharePost post = new InfoSharePost();
+    post.setId(1L);
+    post.setUserId(1L); // Same user ID
+
+    when(infoSharePostRepository.findById(1L)).thenReturn(Optional.of(post));
+
+    // when
+    infoSharePostService.deleteInfoSharePost(1L);
+
+    // then
+    verify(infoSharePostRepository, times(1)).deleteById(1L);
+  }
+
+  @Test
+  void getInfoSharePostsByUserId_success() {
+    // given
+    PageRequest pageable = PageRequest.of(0, 10);
+    InfoSharePost post = new InfoSharePost();
+    post.setId(1L);
+    post.setUserId(1L);
+    post.setTitle("Test Post");
+
+    User user = new User();
+    user.setId(1L);
+    user.setNickName("Test User");
+
+    when(infoSharePostRepository.findAllByUserIdAndTitleContaining(1L, "", pageable))
+        .thenReturn(new PageImpl<>(Collections.singletonList(post)));
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+    // when
+    Page<InfoSharePostDto> result = infoSharePostService.getInfoSharePostsByUserId(1L, 0, "");
+
+    // then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getTitle()).isEqualTo("Test Post");
+  }
+}


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> DevOnOffApplication의 @EnableJpaAuditing으로 인해 테스트 코드가 정상적으로 작동하지 않음
> 변수명이 SECRET_KEY, AWS_BUCKET_NAME, AWS_REGION, AWS_ACCESS_KEY, AWS_SECRET_KEY라서 실제 변수가 의미하는 것과는 약간의 거리가 있음
> 🔖 **TO-BE**
> JpaAuditingConfiguration을 추가해 JpaAuditing은 가능하고 테스트 코드에서도 정상작동하도록 수정
> 변수명이 각각 다음과 같이 변경
> SECRET_KEY -> JWT_SECRET_KEY
> AWS_BUCKET_NAME -> S3_BUCKET_NAME
> AWS_REGION -> S3_REGION
> AWS_ACCESS_KEY -> S3_ACCESS_KEY
> AWS_SECRET_KEY -> S3_SECRET_KEY
> 정보공유 게시판 관련 CRUD와 테스트 코드 추가

> ### 테스트
>
> - [X] 테스트 코드: 테스트 코드가 모두 메서드에 대해 정상작동하는 것을 확인
> - [X] API 테스트: 포스트맨을 통해 유저관련 정보를 넣었을 때도 정상작동하는 것을 확인