### PR TITLE
feat: AuthService내에 getLoginUserId를 추가해 로그인된 유저의 아이디를 불러오는 기능 추가

### DIFF
--- a/src/main/java/com/devonoff/domain/user/service/AuthService.java
+++ b/src/main/java/com/devonoff/domain/user/service/AuthService.java
@@ -22,6 +22,9 @@ import jakarta.transaction.Transactional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -240,6 +243,12 @@ public class AuthService {
     if (existsByEmail) {
       throw new CustomException(ErrorCode.EMAIL_ALREADY_REGISTERED);
     }
+  }
+
+  public Long getLoginUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    return Long.parseLong(userDetails.getUsername());
   }
 
 }


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> 기존에 로그인된 유저 아이디를 확인하기 위해서는 
>```
>    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
>    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
>    Long userId = Long.parseLong(userDetails.getUsername());
>```
> 서비스마다 위 코드를 추가해 확인해야하는 번거로움이 있음

> 🔖 **TO-BE**
>```
>  public Long getLoginUserId() {
>    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
>    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
>    return Long.parseLong(userDetails.getUsername());
>  }
>```
> AuthService 내에 위와같은 메서드를 추가해 기존 서비스는 도메인에 맞는 서비스를 제공하는데만 집중하고 AuthService에서 유저 관련 로직을 처리하도록 넘겨줌