### PR TITLE
fix: multipartfile과 requestBody가 충돌하던 부분을 RequestPart의 file,data로 나눠서 요청을 받도록 수정, 정보공유 게시판의 응답값이 api명세서와 동일하게 변경, 최신순으로 정렬하도록 pageRequest에 sort 추가, 테스트코드 수정

### DIFF
--- a/src/main/java/com/devonoff/domain/infosharepost/controller/InfoSharePostController.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/controller/InfoSharePostController.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,8 +24,8 @@ public class InfoSharePostController {
 
   @PostMapping
   public ResponseEntity<InfoSharePostDto> createInfoSharePost(
-      @RequestParam("file") MultipartFile file,
-      @RequestBody InfoSharePostDto infoSharePost) {
+      @RequestPart("file") MultipartFile file,
+      @RequestPart("data") InfoSharePostDto infoSharePost) {
     var result = this.infoSharePostService.createInfoSharePost(infoSharePost, file);
     return ResponseEntity.ok(result);
   }
@@ -55,8 +55,8 @@ public class InfoSharePostController {
 
   @PostMapping("/{infoPostId}")
   public ResponseEntity<InfoSharePostDto> updateInfoSharePost(@PathVariable Long infoPostId,
-      @RequestParam("file") MultipartFile file,
-      @RequestBody InfoSharePostDto infoSharePostDto) {
+      @RequestPart("file") MultipartFile file,
+      @RequestPart("data") InfoSharePostDto infoSharePostDto) {
     var result = this.infoSharePostService.updateInfoSharePost(infoPostId, infoSharePostDto, file);
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
@@ -13,6 +13,7 @@ import com.devonoff.domain.user.entity.User;
 import com.devonoff.domain.user.repository.UserRepository;
 import com.devonoff.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InfoSharePostService {
@@ -89,6 +91,13 @@ public class InfoSharePostService {
     UserDetails userDetails = (UserDetails) authentication.getPrincipal();
     if (Long.parseLong(userDetails.getUsername()) != infoSharePost.getUser().getId()) {
       throw new CustomException(UNAUTHORIZED_ACCESS);
+    }
+    if (infoSharePost.getThumbnailImgUrl() != null) {
+      try {
+        photoService.delete(infoSharePost.getThumbnailImgUrl());
+      } catch (Exception e) {
+        log.info("존재하지 않는 사진입니다.");
+      }
     }
     this.infoSharePostRepository.deleteById(infoPostId);
   }

--- a/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -46,14 +47,14 @@ public class InfoSharePostService {
   }
 
   public Page<InfoSharePostDto> getInfoSharePosts(Integer page, String search) {
-    Pageable pageable = PageRequest.of(page, 10);
+    Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
     return this.infoSharePostRepository.findAllByTitleContaining(search,
         pageable).map(InfoSharePostDto::fromEntity);
   }
 
   public Page<InfoSharePostDto> getInfoSharePostsByUserId(Long userId, Integer page,
       String search) {
-    Pageable pageable = PageRequest.of(page, 10);
+    Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
     return this.infoSharePostRepository.findAllByUserIdAndTitleContaining(userId, search, pageable)
         .map(InfoSharePostDto::fromEntity);
   }

--- a/src/test/java/com/devonoff/infosharepost/controller/InfoSharePostControllerTest.java
+++ b/src/test/java/com/devonoff/infosharepost/controller/InfoSharePostControllerTest.java
@@ -1,8 +1,7 @@
 package com.devonoff.infosharepost.controller;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -45,30 +44,41 @@ class InfoSharePostControllerTest {
 
   @Test
   void createInfoSharePost_Success() throws Exception {
-    // given
-    MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg",
-        "image content".getBytes());
-    InfoSharePostDto requestDto = InfoSharePostDto.builder()
+    // Given
+    MockMultipartFile file = new MockMultipartFile(
+        "file",
+        "test-image.jpg",
+        "image/jpeg",
+        "mock image content".getBytes()
+    );
+
+    InfoSharePostDto mockRequestDto = InfoSharePostDto.builder()
         .title("Test Title")
-        .description("Test Description")
-        .build();
-    InfoSharePostDto responseDto = InfoSharePostDto.builder()
-        .title("Test Title")
-        .description("Test Description")
-        .thumbnailImgUrl("test-url")
+        .description("Test Content")
         .build();
 
-    Mockito.when(infoSharePostService.createInfoSharePost(any(InfoSharePostDto.class), any()))
-        .thenReturn(responseDto);
+    MockMultipartFile data = new MockMultipartFile(
+        "data",
+        "",
+        "application/json",
+        objectMapper.writeValueAsBytes(mockRequestDto)
+    );
 
-    // when & then
+    InfoSharePostDto mockResponseDto = InfoSharePostDto.builder()
+        .id(1L)
+        .title(mockRequestDto.getTitle())
+        .description(mockRequestDto.getDescription())
+        .build();
+
+    when(infoSharePostService.createInfoSharePost(mockRequestDto, file)).thenReturn(
+        mockResponseDto);
+
+    // When & Then
     mockMvc.perform(multipart("/api/info-posts")
             .file(file)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(requestDto)))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.title").value("Test Title"))
-        .andExpect(jsonPath("$.thumbnailImgUrl").value("test-url"));
+            .file(data)
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isOk());
   }
 
   @Test
@@ -78,7 +88,7 @@ class InfoSharePostControllerTest {
         InfoSharePostDto.builder().title("Test Title").build()
     ));
 
-    Mockito.when(infoSharePostService.getInfoSharePosts(0, ""))
+    when(infoSharePostService.getInfoSharePosts(0, ""))
         .thenReturn(page);
 
     // when & then
@@ -97,7 +107,7 @@ class InfoSharePostControllerTest {
         .description("Test Description")
         .build();
 
-    Mockito.when(infoSharePostService.getInfoSharePostByPostId(anyLong()))
+    when(infoSharePostService.getInfoSharePostByPostId(anyLong()))
         .thenReturn(responseDto);
 
     // when & then
@@ -108,29 +118,42 @@ class InfoSharePostControllerTest {
 
   @Test
   void updateInfoSharePost_Success() throws Exception {
-    // given
-    MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg",
-        "image content".getBytes());
-    InfoSharePostDto requestDto = InfoSharePostDto.builder()
+    // Given
+    Long postId = 1L;
+    MockMultipartFile file = new MockMultipartFile(
+        "file",
+        "updated-image.jpg",
+        "image/jpeg",
+        "updated mock image content".getBytes()
+    );
+
+    InfoSharePostDto mockRequestDto = InfoSharePostDto.builder()
         .title("Updated Title")
-        .description("Updated Description")
-        .build();
-    InfoSharePostDto responseDto = InfoSharePostDto.builder()
-        .title("Updated Title")
-        .description("Updated Description")
+        .description("Updated Content")
         .build();
 
-    Mockito.when(
-            infoSharePostService.updateInfoSharePost(eq(1L), any(InfoSharePostDto.class), any()))
-        .thenReturn(responseDto);
+    MockMultipartFile data = new MockMultipartFile(
+        "data",
+        "",
+        "application/json",
+        objectMapper.writeValueAsBytes(mockRequestDto)
+    );
 
-    // when & then
-    mockMvc.perform(multipart("/api/info-posts/1")
+    InfoSharePostDto mockResponseDto = InfoSharePostDto.builder()
+        .id(postId)
+        .title(mockRequestDto.getTitle())
+        .description(mockRequestDto.getDescription())
+        .build();
+
+    when(infoSharePostService.updateInfoSharePost(postId, mockRequestDto, file)).thenReturn(
+        mockResponseDto);
+
+    // When & Then
+    mockMvc.perform(multipart("/api/info-posts/{infoPostId}", postId)
             .file(file)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(requestDto)))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.title").value("Updated Title"));
+            .file(data)
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isOk());
   }
 
   @Test


### PR DESCRIPTION
fix: multipartfile과 requestBody가 충돌하던 부분을 RequestPart의 file,data로 나눠서 요청을 받도록 수정, 정보공유 게시판의 응답값이 api명세서와 동일하게 변경, 최신순으로 정렬하도록 pageRequest에 sort 추가, 테스트 코드 수정

### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> MultiPartFile과 RequestBody가 충돌해 서버에서 정상적으로 요청을 받아들이지 못함
> page내 데이터들이 최신순으로 정렬되지 않음
> 🔖 **TO-BE**
> RequestPart에 file,data를 key로 두어 각각에 파일과 게시글에 관한 정보를 보내도록 변경
> page내 데이터들이 최신순으로 정렬되어 나옴

> ### 테스트
> - [X] 테스트 코드: 변경 내용에 따라 수정한 테스트 코드 정상작동 확인
> - [X] API 테스트: 포스트맨으로 정상적으로 작동하는 것을 확인