### PR TITLE
스터디 모집글 관련 기능(성공/실패 케이스) 테스트 코드 작성

### DIFF
--- a/src/main/java/com/devonoff/config/BatchConfig.java
+++ b/src/main/java/com/devonoff/config/BatchConfig.java
@@ -3,6 +3,7 @@ package com.devonoff.config;
 import com.devonoff.domain.studyPost.repository.StudyPostRepository;
 import com.devonoff.domain.studyPost.service.StudyPostService;
 import com.devonoff.type.StudyPostStatus;
+import com.devonoff.util.TimeProvider;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
@@ -23,6 +24,7 @@ public class BatchConfig extends DefaultBatchConfiguration {
 
   private final StudyPostRepository studyPostRepository;
   private final StudyPostService studyPostService;
+  private final TimeProvider timeProvider;
 
   @Bean
   public Job deleteOldStudyPostsJob(JobRepository jobRepository,
@@ -43,7 +45,7 @@ public class BatchConfig extends DefaultBatchConfiguration {
   @Bean
   public Tasklet deleteTasklet() {
     return (contribution, chunkContext) -> {
-      LocalDateTime oneWeekAgo = LocalDateTime.now().minusDays(7);
+      LocalDateTime oneWeekAgo = timeProvider.now().minusDays(7);
 
       // 모집 기한이 지난 스터디 모집글을 CANCELED 로 변경(배치작업으로 자동 취소)
       studyPostService.cancelStudyPostIfExpired();

--- a/src/main/java/com/devonoff/domain/study/service/StudyService.java
+++ b/src/main/java/com/devonoff/domain/study/service/StudyService.java
@@ -14,6 +14,7 @@ import com.devonoff.domain.user.service.AuthService;
 import com.devonoff.exception.CustomException;
 import com.devonoff.type.ErrorCode;
 import com.devonoff.type.StudyStatus;
+import com.devonoff.util.TimeProvider;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/devonoff/domain/studyPost/controller/StudyPostController.java
+++ b/src/main/java/com/devonoff/domain/studyPost/controller/StudyPostController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -81,7 +80,7 @@ public class StudyPostController {
     return ResponseEntity.ok().build();
   }
 
-  // 스터디 모집글 모집 취소 (삭제 스케줄링)
+  // 스터디 모집글 모집 취소
   @PatchMapping("/{studyPostId}/cancel")
   public ResponseEntity<Void> cancelStudyPost(@PathVariable Long studyPostId) {
     studyPostService.cancelStudyPost(studyPostId);

--- a/src/main/java/com/devonoff/domain/studyPost/dto/StudyPostDto.java
+++ b/src/main/java/com/devonoff/domain/studyPost/dto/StudyPostDto.java
@@ -15,8 +15,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/devonoff/util/TimeProvider.java
+++ b/src/main/java/com/devonoff/util/TimeProvider.java
@@ -1,4 +1,4 @@
-package com.devonoff.domain.study.service;
+package com.devonoff.util;
 
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;

--- a/src/test/java/com/devonoff/config/BatchConfigTest.java
+++ b/src/test/java/com/devonoff/config/BatchConfigTest.java
@@ -1,0 +1,67 @@
+package com.devonoff.config;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.devonoff.domain.studyPost.repository.StudyPostRepository;
+import com.devonoff.domain.studyPost.service.StudyPostService;
+import com.devonoff.type.StudyPostStatus;
+import com.devonoff.util.TimeProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+class BatchConfigTest {
+
+  @Mock
+  private StudyPostRepository studyPostRepository;
+
+  @Mock
+  private StudyPostService studyPostService;
+
+  @Mock
+  private TimeProvider timeProvider;
+
+  @InjectMocks
+  private BatchConfig batchConfig;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @DisplayName("배치 작업 성공 - 모집 기한이 지난 모집글 취소 및 삭제")
+  @Test
+  void deleteTasklet_Success() throws Exception {
+    // Given
+    LocalDateTime fixedNow = LocalDateTime.of(2024, 12, 5, 22, 29, 11);
+    when(timeProvider.now()).thenReturn(fixedNow);
+
+    LocalDateTime oneWeekAgo = fixedNow.minusDays(7);
+
+    doNothing().when(studyPostService).cancelStudyPostIfExpired();
+    doNothing().when(studyPostRepository).deleteByStatusAndUpdatedAtBefore(
+        eq(StudyPostStatus.CANCELED), eq(oneWeekAgo)
+    );
+
+    // When
+    RepeatStatus status = batchConfig.deleteTasklet().execute(null, mock(ChunkContext.class));
+
+    // Then
+    verify(timeProvider, times(1)).now();
+    verify(studyPostService, times(1)).cancelStudyPostIfExpired();
+    verify(studyPostRepository, times(1))
+        .deleteByStatusAndUpdatedAtBefore(eq(StudyPostStatus.CANCELED), eq(oneWeekAgo));
+    assert status == RepeatStatus.FINISHED;
+  }
+}

--- a/src/test/java/com/devonoff/domain/study/service/StudyServiceTest.java
+++ b/src/test/java/com/devonoff/domain/study/service/StudyServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import com.devonoff.domain.study.entity.Study;
 import com.devonoff.domain.study.repository.StudyRepository;
 import com.devonoff.type.StudyStatus;
+import com.devonoff.util.TimeProvider;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
@@ -567,4 +567,60 @@ class StudyPostControllerTest {
     verify(studyPostService, times(1)).closeStudyPost(studyPostId);
   }
 
+  @DisplayName("스터디 모집글 모집 마감 실패 - 모집글 없음")
+  @Test
+  void closeStudyPost_Fail_StudyPostNotFound() throws Exception {
+    // Given
+    Long studyPostId = 999L;
+
+    doThrow(new CustomException(ErrorCode.STUDY_POST_NOT_FOUND))
+        .when(studyPostService).closeStudyPost(studyPostId);
+
+    // When & Then
+    mockMvc.perform(patch("/api/study-posts/{studyPostId}/close", studyPostId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound()) // HTTP 404 상태 확인
+        .andExpect(content().string("스터디 모집글을 찾을 수 없습니다."))
+        .andDo(print());
+
+    verify(studyPostService, times(1)).closeStudyPost(studyPostId);
+  }
+
+  @DisplayName("스터디 모집글 모집 마감 실패 - 모집 상태가 모집 중이 아님")
+  @Test
+  void closeStudyPost_Fail_InvalidStudyStatus() throws Exception {
+    // Given
+    Long studyPostId = 1L;
+
+    doThrow(new CustomException(ErrorCode.INVALID_STUDY_STATUS))
+        .when(studyPostService).closeStudyPost(studyPostId);
+
+    // When & Then
+    mockMvc.perform(patch("/api/study-posts/{studyPostId}/close", studyPostId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest()) // 400
+        .andExpect(content().string("잘못된 스터디 상태값입니다."))
+        .andDo(print());
+
+    verify(studyPostService, times(1)).closeStudyPost(studyPostId);
+  }
+
+  @DisplayName("스터디 모집글 마감 실패 - 승인된 신청자가 없음")
+  @Test
+  void closeStudyPost_Fail_NoApprovedSignups() throws Exception {
+    // Given
+    Long studyPostId = 1L;
+
+    doThrow(new CustomException(ErrorCode.NO_APPROVED_SIGNUPS))
+        .when(studyPostService).closeStudyPost(studyPostId);
+
+    // When & Then
+    mockMvc.perform(patch("/api/study-posts/{studyPostId}/close", studyPostId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest()) // 400
+        .andExpect(content().string("승인된 신청자가 없습니다."))
+        .andDo(print());
+
+    verify(studyPostService, times(1)).closeStudyPost(studyPostId);
+  }
 }

--- a/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
@@ -1,6 +1,7 @@
 package com.devonoff.domain.studyPost.controller;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,6 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -103,5 +107,68 @@ class StudyPostControllerTest {
     mockMvc.perform(get("/api/study-posts/{studyPostId}", studyPostId)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
+  }
+
+  @DisplayName("스터디 모집글 검색 성공")
+  @Test
+  void searchStudyPosts_Success() throws Exception {
+    // Given
+    StudyPostDto studyPostDto = new StudyPostDto();
+    studyPostDto.setId(1L);
+    studyPostDto.setTitle("코딩 테스트 준비");
+    studyPostDto.setStudyName("코테");
+    studyPostDto.setSubject(StudySubject.JOB_PREPARATION);
+    studyPostDto.setDifficulty(StudyDifficulty.MEDIUM);
+    studyPostDto.setDayType(List.of("월", "화"));
+    studyPostDto.setStartDate(LocalDate.parse("2024-12-04"));
+    studyPostDto.setEndDate(LocalDate.parse("2024-12-22"));
+    studyPostDto.setStartTime(LocalTime.parse("19:00"));
+    studyPostDto.setEndTime(LocalTime.parse("21:00"));
+    studyPostDto.setMeetingType(StudyMeetingType.ONLINE);
+    studyPostDto.setRecruitmentPeriod(LocalDate.parse("2024-11-30"));
+    studyPostDto.setDescription("코테 공부할사람 모여");
+    studyPostDto.setLatitude(37.5665);
+    studyPostDto.setLongitude(126.9780);
+    studyPostDto.setMaxParticipants(5);
+    studyPostDto.setUserId(11L);
+
+    Page<StudyPostDto> mockPage = new PageImpl<>(List.of(studyPostDto), PageRequest.of(0, 20), 1);
+
+    Mockito.when(studyPostService.searchStudyPosts(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+            Mockito.anyInt(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(mockPage);
+
+    // When & Then
+    mockMvc.perform(get("/api/study-posts/search")
+            .param("meetingType", "ONLINE")
+            .param("title", "코테")
+            .param("subject", "JOB_PREPARATION")
+            .param("difficulty", "MEDIUM")
+            .param("dayType", "3")
+            .param("status", "RECRUITING")
+            .param("latitude", "37.5665")
+            .param("longitude", "126.9780")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].id").value(1L))
+        .andExpect(jsonPath("$.content[0].title").value("코딩 테스트 준비"))
+        .andExpect(jsonPath("$.content[0].studyName").value("코테"))
+        .andExpect(jsonPath("$.content[0].subject").value("JOB_PREPARATION"))
+        .andExpect(jsonPath("$.content[0].difficulty").value("MEDIUM"))
+        .andExpect(jsonPath("$.content[0].dayType[0]").value("월"))
+        .andExpect(jsonPath("$.content[0].dayType[1]").value("화"))
+        .andExpect(jsonPath("$.content[0].startDate").value("2024-12-04"))
+        .andExpect(jsonPath("$.content[0].endDate").value("2024-12-22"))
+        .andExpect(jsonPath("$.content[0].startTime").value("19:00:00"))
+        .andExpect(jsonPath("$.content[0].endTime").value("21:00:00"))
+        .andExpect(jsonPath("$.content[0].meetingType").value("ONLINE"))
+        .andExpect(jsonPath("$.content[0].recruitmentPeriod").value("2024-11-30"))
+        .andExpect(jsonPath("$.content[0].description").value("코테 공부할사람 모여"))
+        .andExpect(jsonPath("$.content[0].latitude").value(37.5665))
+        .andExpect(jsonPath("$.content[0].longitude").value(126.9780))
+        .andExpect(jsonPath("$.content[0].maxParticipants").value(5))
+        .andExpect(jsonPath("$.content[0].userId").value(11L));
   }
 }

--- a/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
@@ -1,0 +1,107 @@
+package com.devonoff.domain.studyPost.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devonoff.domain.studyPost.dto.StudyPostDto;
+import com.devonoff.domain.studyPost.service.StudyPostService;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
+import com.devonoff.type.StudyDifficulty;
+import com.devonoff.type.StudyMeetingType;
+import com.devonoff.type.StudySubject;
+import com.devonoff.util.JwtProvider;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = StudyPostController.class)
+@ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc(addFilters = false) // Security 필터 비활성화
+class StudyPostControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private StudyPostService studyPostService;
+
+  @MockBean
+  private JwtProvider jwtProvider;
+
+  @DisplayName("스터디 모집글 상세 조회 성공")
+  @Test
+  void getStudyPostDetail_Success() throws Exception {
+    Long studyPostId = 1L;
+
+    StudyPostDto studyPostDto = new StudyPostDto();
+    studyPostDto.setId(studyPostId);
+    studyPostDto.setTitle("스터디 모집글! 상세 조회 테스트");
+    studyPostDto.setStudyName("코테");
+    studyPostDto.setSubject(StudySubject.JOB_PREPARATION);
+    studyPostDto.setDifficulty(StudyDifficulty.HIGH);
+    studyPostDto.setDayType(List.of("월", "화"));
+    studyPostDto.setStartDate(LocalDate.parse("2024-12-04"));
+    studyPostDto.setEndDate(LocalDate.parse("2024-12-22"));
+    studyPostDto.setStartTime(LocalTime.parse("19:00"));
+    studyPostDto.setEndTime(LocalTime.parse("21:00"));
+    studyPostDto.setMeetingType(StudyMeetingType.HYBRID);
+    studyPostDto.setRecruitmentPeriod(LocalDate.parse("2024-11-30"));
+    studyPostDto.setDescription("코테 공부할사람 모여");
+    studyPostDto.setLatitude(35.6895);
+    studyPostDto.setLongitude(139.6917);
+    studyPostDto.setMaxParticipants(5);
+    studyPostDto.setUserId(11L);
+
+    Mockito.when(studyPostService.getStudyPostDetail(studyPostId)).thenReturn(studyPostDto);
+
+    mockMvc.perform(get("/api/study-posts/{studyPostId}", studyPostId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(studyPostId))
+        .andExpect(jsonPath("$.title").value("스터디 모집글! 상세 조회 테스트"))
+        .andExpect(jsonPath("$.studyName").value("코테"))
+        .andExpect(jsonPath("$.subject").value("JOB_PREPARATION"))
+        .andExpect(jsonPath("$.difficulty").value("HIGH"))
+        .andExpect(jsonPath("$.dayType", contains("월", "화")))
+        .andExpect(jsonPath("$.startDate").value("2024-12-04"))
+        .andExpect(jsonPath("$.endDate").value("2024-12-22"))
+        .andExpect(jsonPath("$.startTime").value("19:00:00"))
+        .andExpect(jsonPath("$.endTime").value("21:00:00"))
+        .andExpect(jsonPath("$.meetingType").value("HYBRID"))
+        .andExpect(jsonPath("$.recruitmentPeriod").value("2024-11-30"))
+        .andExpect(jsonPath("$.description").value("코테 공부할사람 모여"))
+        .andExpect(jsonPath("$.latitude").value(35.6895))
+        .andExpect(jsonPath("$.longitude").value(139.6917))
+        .andExpect(jsonPath("$.maxParticipants").value(5))
+        .andExpect(jsonPath("$.userId").value(11L));
+  }
+
+  @DisplayName("스터디 모집글 상세 조회 실패")
+  @Test
+  void getStudyPostDetail_NotFound() throws Exception {
+    // Given
+    Long studyPostId = 123L;
+
+    Mockito.when(studyPostService.getStudyPostDetail(studyPostId))
+        .thenThrow(new CustomException(ErrorCode.STUDY_POST_NOT_FOUND));
+
+    // When & Then
+    mockMvc.perform(get("/api/study-posts/{studyPostId}", studyPostId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
@@ -3,9 +3,11 @@ package com.devonoff.domain.studyPost.controller;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.devonoff.domain.studyPost.dto.StudyPostCreateRequest;
 import com.devonoff.domain.studyPost.dto.StudyPostDto;
 import com.devonoff.domain.studyPost.service.StudyPostService;
 import com.devonoff.exception.CustomException;
@@ -30,6 +32,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = StudyPostController.class)
@@ -170,5 +173,76 @@ class StudyPostControllerTest {
         .andExpect(jsonPath("$.content[0].longitude").value(126.9780))
         .andExpect(jsonPath("$.content[0].maxParticipants").value(5))
         .andExpect(jsonPath("$.content[0].userId").value(11L));
+  }
+
+  @DisplayName("스터디 모집글 생성 성공")
+  @Test
+  void createStudyPost_Success() throws Exception {
+    // Given
+    MockMultipartFile file = new MockMultipartFile(
+        "file",
+        "test-image.jpg",
+        MediaType.IMAGE_JPEG_VALUE,
+        "Test Image Content".getBytes()
+    );
+
+    StudyPostDto response = StudyPostDto.builder()
+        .id(1L)
+        .title("코딩 테스트 준비")
+        .studyName("코테")
+        .subject(StudySubject.JOB_PREPARATION)
+        .difficulty(StudyDifficulty.MEDIUM)
+        .dayType(List.of("월", "화"))
+        .startDate(LocalDate.of(2024, 12, 10))
+        .endDate(LocalDate.of(2024, 12, 20))
+        .startTime(LocalTime.of(18, 0))
+        .endTime(LocalTime.of(20, 0))
+        .meetingType(StudyMeetingType.ONLINE)
+        .recruitmentPeriod(LocalDate.of(2024, 12, 5))
+        .description("코딩 테스트 스터디 모집")
+        .maxParticipants(5)
+        .userId(1L)
+        .thumbnailImgUrl("mock_thumbnail_url")
+        .build();
+
+    Mockito.when(studyPostService.createStudyPost(Mockito.any(StudyPostCreateRequest.class)))
+        .thenReturn(response);
+
+    // When & Then
+    mockMvc.perform(multipart("/api/study-posts")
+            .file(file)
+            .param("title", "코딩 테스트 준비")
+            .param("studyName", "코테")
+            .param("subject", "JOB_PREPARATION")
+            .param("difficulty", "MEDIUM")
+            .param("dayType", "월", "화")
+            .param("startDate", "2024-12-10")
+            .param("endDate", "2024-12-20")
+            .param("startTime", "18:00")
+            .param("endTime", "20:00")
+            .param("meetingType", "ONLINE")
+            .param("recruitmentPeriod", "2024-12-05")
+            .param("description", "코딩 테스트 스터디 모집")
+            .param("maxParticipants", "5")
+            .param("userId", "1")
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.title").value("코딩 테스트 준비"))
+        .andExpect(jsonPath("$.studyName").value("코테"))
+        .andExpect(jsonPath("$.subject").value("JOB_PREPARATION"))
+        .andExpect(jsonPath("$.difficulty").value("MEDIUM"))
+        .andExpect(jsonPath("$.dayType[0]").value("월"))
+        .andExpect(jsonPath("$.dayType[1]").value("화"))
+        .andExpect(jsonPath("$.startDate").value("2024-12-10"))
+        .andExpect(jsonPath("$.endDate").value("2024-12-20"))
+        .andExpect(jsonPath("$.startTime").value("18:00:00"))
+        .andExpect(jsonPath("$.endTime").value("20:00:00"))
+        .andExpect(jsonPath("$.meetingType").value("ONLINE"))
+        .andExpect(jsonPath("$.recruitmentPeriod").value("2024-12-05"))
+        .andExpect(jsonPath("$.description").value("코딩 테스트 스터디 모집"))
+        .andExpect(jsonPath("$.maxParticipants").value(5))
+        .andExpect(jsonPath("$.userId").value(1L))
+        .andExpect(jsonPath("$.thumbnailImgUrl").value("mock_thumbnail_url"));
   }
 }

--- a/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/controller/StudyPostControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -547,4 +548,23 @@ class StudyPostControllerTest {
     verify(studyPostService, times(1)).updateStudyPost(eq(studyPostId),
         any(StudyPostUpdateRequest.class));
   }
+
+  @DisplayName("스터디 모집글 모집 마감 성공")
+  @Test
+  void closeStudyPost_Success() throws Exception {
+    // Given
+    Long studyPostId = 1L;
+    Long leaderId = 1L;
+
+    when(authService.getLoginUserId()).thenReturn(leaderId);
+
+    // When & Then
+    mockMvc.perform(patch("/api/study-posts/{studyPostId}/close", studyPostId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andDo(print());
+
+    verify(studyPostService, times(1)).closeStudyPost(studyPostId);
+  }
+
 }

--- a/src/test/java/com/devonoff/domain/studyPost/service/StudyPostServiceTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/service/StudyPostServiceTest.java
@@ -1,0 +1,105 @@
+package com.devonoff.domain.studyPost.service;
+
+import com.devonoff.domain.studyPost.dto.StudyPostDto;
+import com.devonoff.domain.studyPost.entity.StudyPost;
+import com.devonoff.domain.studyPost.repository.StudyPostRepository;
+import com.devonoff.domain.user.entity.User;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
+import com.devonoff.type.StudyDifficulty;
+import com.devonoff.type.StudyMeetingType;
+import com.devonoff.type.StudySubject;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudyPostServiceTest {
+
+  @Mock
+  private StudyPostRepository studyPostRepository;
+
+  @InjectMocks
+  private StudyPostService studyPostService;
+
+  @DisplayName("스터디 모집글 상세 조회 성공")
+  @Test
+  void getStudyPostDetail_Success() {
+    // Given
+    Long studyPostId = 1L;
+
+    User user = new User();
+    user.setId(11L);
+
+    StudyPost studyPost = new StudyPost();
+    studyPost.setId(studyPostId);
+    studyPost.setTitle("스터디 모집글! 상세 조회 테스트");
+    studyPost.setStudyName("코테");
+    studyPost.setSubject(StudySubject.JOB_PREPARATION);
+    studyPost.setDifficulty(StudyDifficulty.HIGH);
+    studyPost.setDayType(3);
+    studyPost.setStartDate(LocalDate.parse("2024-12-04"));
+    studyPost.setEndDate(LocalDate.parse("2024-12-22"));
+    studyPost.setStartTime(LocalTime.parse("19:00"));
+    studyPost.setEndTime(LocalTime.parse("21:00"));
+    studyPost.setMeetingType(StudyMeetingType.HYBRID);
+    studyPost.setRecruitmentPeriod(LocalDate.parse("2024-11-30"));
+    studyPost.setDescription("코테 공부할사람 모여");
+    studyPost.setLatitude(35.6895);
+    studyPost.setLongitude(139.6917);
+    studyPost.setMaxParticipants(5);
+    studyPost.setUser(user);
+
+    Mockito.when(studyPostRepository.findById(studyPostId))
+        .thenReturn(Optional.of(studyPost));
+
+    // When
+    StudyPostDto result = studyPostService.getStudyPostDetail(studyPostId);
+
+    // Then
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(studyPostId, result.getId());
+    Assertions.assertEquals("스터디 모집글! 상세 조회 테스트", result.getTitle());
+    Assertions.assertEquals("코테", result.getStudyName());
+    Assertions.assertEquals(StudySubject.JOB_PREPARATION, result.getSubject());
+    Assertions.assertEquals(StudyDifficulty.HIGH, result.getDifficulty());
+    Assertions.assertEquals(List.of("월", "화"), result.getDayType());
+    Assertions.assertEquals(LocalDate.parse("2024-12-04"), result.getStartDate());
+    Assertions.assertEquals(LocalDate.parse("2024-12-22"), result.getEndDate());
+    Assertions.assertEquals(LocalTime.parse("19:00"), result.getStartTime());
+    Assertions.assertEquals(LocalTime.parse("21:00"), result.getEndTime());
+    Assertions.assertEquals(StudyMeetingType.HYBRID, result.getMeetingType());
+    Assertions.assertEquals(LocalDate.parse("2024-11-30"), result.getRecruitmentPeriod());
+    Assertions.assertEquals("코테 공부할사람 모여", result.getDescription());
+    Assertions.assertEquals(35.6895, result.getLatitude());
+    Assertions.assertEquals(139.6917, result.getLongitude());
+    Assertions.assertEquals(5, result.getMaxParticipants());
+    Assertions.assertEquals(11L, result.getUserId());
+  }
+
+  @DisplayName("스터디 모집글 상세 조회 실패")
+  @Test
+  void getStudyPostDetail_NotFound() {
+    // Given
+    Long studyPostId = 123L;
+
+    // Optional.empty()를 반환하도록 설정
+    Mockito.when(studyPostRepository.findById(studyPostId))
+        .thenReturn(Optional.empty());
+
+    // When & Then
+    CustomException exception = Assertions.assertThrows(CustomException.class,
+        () -> studyPostService.getStudyPostDetail(studyPostId));
+
+    Assertions.assertEquals(ErrorCode.STUDY_POST_NOT_FOUND, exception.getErrorCode());
+  }
+}

--- a/src/test/java/com/devonoff/domain/studyPost/service/StudyPostServiceTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/service/StudyPostServiceTest.java
@@ -1,17 +1,27 @@
 package com.devonoff.domain.studyPost.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+import com.devonoff.domain.photo.service.PhotoService;
+import com.devonoff.domain.studyPost.dto.StudyPostCreateRequest;
 import com.devonoff.domain.studyPost.dto.StudyPostDto;
 import com.devonoff.domain.studyPost.entity.StudyPost;
 import com.devonoff.domain.studyPost.repository.StudyPostRepository;
 import com.devonoff.domain.user.entity.User;
+import com.devonoff.domain.user.repository.UserRepository;
+import com.devonoff.domain.user.service.AuthService;
 import com.devonoff.exception.CustomException;
 import com.devonoff.type.ErrorCode;
 import com.devonoff.type.StudyDifficulty;
 import com.devonoff.type.StudyMeetingType;
 import com.devonoff.type.StudyPostStatus;
 import com.devonoff.type.StudySubject;
+import com.devonoff.util.DayTypeUtils;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -28,12 +38,22 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class StudyPostServiceTest {
 
   @Mock
   private StudyPostRepository studyPostRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PhotoService photoService;
+
+  @Mock
+  private AuthService authService;
 
   @InjectMocks
   private StudyPostService studyPostService;
@@ -72,24 +92,24 @@ class StudyPostServiceTest {
     StudyPostDto result = studyPostService.getStudyPostDetail(studyPostId);
 
     // Then
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(studyPostId, result.getId());
-    Assertions.assertEquals("스터디 모집글! 상세 조회 테스트", result.getTitle());
-    Assertions.assertEquals("코테", result.getStudyName());
-    Assertions.assertEquals(StudySubject.JOB_PREPARATION, result.getSubject());
-    Assertions.assertEquals(StudyDifficulty.HIGH, result.getDifficulty());
-    Assertions.assertEquals(List.of("월", "화"), result.getDayType());
-    Assertions.assertEquals(LocalDate.parse("2024-12-04"), result.getStartDate());
-    Assertions.assertEquals(LocalDate.parse("2024-12-22"), result.getEndDate());
-    Assertions.assertEquals(LocalTime.parse("19:00"), result.getStartTime());
-    Assertions.assertEquals(LocalTime.parse("21:00"), result.getEndTime());
-    Assertions.assertEquals(StudyMeetingType.HYBRID, result.getMeetingType());
-    Assertions.assertEquals(LocalDate.parse("2024-11-30"), result.getRecruitmentPeriod());
-    Assertions.assertEquals("코테 공부할사람 모여", result.getDescription());
-    Assertions.assertEquals(35.6895, result.getLatitude());
-    Assertions.assertEquals(139.6917, result.getLongitude());
-    Assertions.assertEquals(5, result.getMaxParticipants());
-    Assertions.assertEquals(11L, result.getUserId());
+    assertNotNull(result);
+    assertEquals(studyPostId, result.getId());
+    assertEquals("스터디 모집글! 상세 조회 테스트", result.getTitle());
+    assertEquals("코테", result.getStudyName());
+    assertEquals(StudySubject.JOB_PREPARATION, result.getSubject());
+    assertEquals(StudyDifficulty.HIGH, result.getDifficulty());
+    assertEquals(List.of("월", "화"), result.getDayType());
+    assertEquals(LocalDate.parse("2024-12-04"), result.getStartDate());
+    assertEquals(LocalDate.parse("2024-12-22"), result.getEndDate());
+    assertEquals(LocalTime.parse("19:00"), result.getStartTime());
+    assertEquals(LocalTime.parse("21:00"), result.getEndTime());
+    assertEquals(StudyMeetingType.HYBRID, result.getMeetingType());
+    assertEquals(LocalDate.parse("2024-11-30"), result.getRecruitmentPeriod());
+    assertEquals("코테 공부할사람 모여", result.getDescription());
+    assertEquals(35.6895, result.getLatitude());
+    assertEquals(139.6917, result.getLongitude());
+    assertEquals(5, result.getMaxParticipants());
+    assertEquals(11L, result.getUserId());
   }
 
   @DisplayName("스터디 모집글 상세 조회 실패")
@@ -102,10 +122,10 @@ class StudyPostServiceTest {
     when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.empty());
 
     // When & Then
-    CustomException exception = Assertions.assertThrows(CustomException.class,
+    CustomException exception = assertThrows(CustomException.class,
         () -> studyPostService.getStudyPostDetail(studyPostId));
 
-    Assertions.assertEquals(ErrorCode.STUDY_POST_NOT_FOUND, exception.getErrorCode());
+    assertEquals(ErrorCode.STUDY_POST_NOT_FOUND, exception.getErrorCode());
   }
 
   @DisplayName("스터디 모집글 검색 성공")
@@ -144,15 +164,98 @@ class StudyPostServiceTest {
         difficulty, dayType, status, latitude, longitude, pageable);
 
     // Then
-    Assertions.assertNotNull(result, "Result should not be null");
-    Assertions.assertEquals(1, result.getTotalElements(), "Total elements should match");
-    Assertions.assertEquals("코딩 테스트 준비", result.getContent().get(0).getTitle(),
+    assertNotNull(result, "Result should not be null");
+    assertEquals(1, result.getTotalElements(), "Total elements should match");
+    assertEquals("코딩 테스트 준비", result.getContent().get(0).getTitle(),
         "Title should match");
-    Assertions.assertEquals("코테", result.getContent().get(0).getStudyName(),
+    assertEquals("코테", result.getContent().get(0).getStudyName(),
         "Study name should match");
-    Assertions.assertEquals(StudySubject.JOB_PREPARATION, result.getContent().get(0).getSubject(),
+    assertEquals(StudySubject.JOB_PREPARATION, result.getContent().get(0).getSubject(),
         "Subject should match");
-    Assertions.assertEquals(StudyDifficulty.MEDIUM, result.getContent().get(0).getDifficulty(),
+    assertEquals(StudyDifficulty.MEDIUM, result.getContent().get(0).getDifficulty(),
         "Difficulty should match");
+  }
+
+  @DisplayName("스터디 모집글 생성 성공")
+  @Test
+  void createStudyPost_Success() {
+    // Given
+    Long loggedInUserId = 1L; // 현재 사용자
+    Long userId = loggedInUserId; // 요청 사용자
+    MultipartFile mockFile = mock(MultipartFile.class);
+
+    StudyPostCreateRequest request = StudyPostCreateRequest.builder()
+        .title("코딩 테스트 준비")
+        .studyName("코테")
+        .subject(StudySubject.JOB_PREPARATION)
+        .difficulty(StudyDifficulty.MEDIUM)
+        .dayType(List.of("월", "화"))
+        .startDate(LocalDate.of(2024, 12, 10))
+        .endDate(LocalDate.of(2024, 12, 20))
+        .startTime(LocalTime.of(18, 0))
+        .endTime(LocalTime.of(20, 0))
+        .meetingType(StudyMeetingType.ONLINE)
+        .recruitmentPeriod(LocalDate.of(2024, 12, 5))
+        .description("코딩 테스트 스터디 모집")
+        .latitude(null)
+        .longitude(null)
+        .maxParticipants(5)
+        .userId(userId)
+        .file(mockFile)
+        .build();
+
+    User user = new User();
+    user.setId(userId);
+
+    StudyPost studyPost = StudyPost.builder()
+        .id(1L)
+        .title(request.getTitle())
+        .studyName(request.getStudyName())
+        .subject(request.getSubject())
+        .difficulty(request.getDifficulty())
+        .dayType(DayTypeUtils.encodeDaysFromRequest(request.getDayType()))
+        .startDate(request.getStartDate())
+        .endDate(request.getEndDate())
+        .startTime(request.getStartTime())
+        .endTime(request.getEndTime())
+        .meetingType(request.getMeetingType())
+        .recruitmentPeriod(request.getRecruitmentPeriod())
+        .description(request.getDescription())
+        .maxParticipants(request.getMaxParticipants())
+        .user(user)
+        .status(null) // 기본값
+        .thumbnailImgUrl("mock_thumbnail_url")
+        .build();
+
+    Mockito.when(authService.getLoginUserId()).thenReturn(loggedInUserId);
+
+    Mockito.when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    Mockito.when(photoService.save(mockFile)).thenReturn("mock_thumbnail_url");
+    Mockito.when(studyPostRepository.save(Mockito.any(StudyPost.class))).thenReturn(studyPost);
+
+    // When
+    StudyPostDto result = studyPostService.createStudyPost(request);
+
+    // Then
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(request.getTitle(), result.getTitle());
+    Assertions.assertEquals(request.getStudyName(), result.getStudyName());
+    Assertions.assertEquals(request.getSubject(), result.getSubject());
+    Assertions.assertEquals(request.getDifficulty(), result.getDifficulty());
+    Assertions.assertEquals(request.getDayType(), result.getDayType());
+    Assertions.assertEquals(request.getStartDate(), result.getStartDate());
+    Assertions.assertEquals(request.getEndDate(), result.getEndDate());
+    Assertions.assertEquals(request.getStartTime(), result.getStartTime());
+    Assertions.assertEquals(request.getEndTime(), result.getEndTime());
+    Assertions.assertEquals(request.getMeetingType(), result.getMeetingType());
+    Assertions.assertEquals(request.getRecruitmentPeriod(), result.getRecruitmentPeriod());
+    Assertions.assertEquals(request.getDescription(), result.getDescription());
+    Assertions.assertEquals(userId, result.getUserId());
+    Assertions.assertEquals("mock_thumbnail_url", result.getThumbnailImgUrl());
+
+    Mockito.verify(authService, times(1)).getLoginUserId();
+    Mockito.verify(userRepository, times(1)).findById(userId);
+    Mockito.verify(photoService, times(1)).save(mockFile);
+    Mockito.verify(studyPostRepository, times(1)).save(Mockito.any(StudyPost.class));
   }
 }


### PR DESCRIPTION
### Pull Request

> ### 변경사항

> 📌 **AS-IS**

> 🔖 **TO-BE**

### 스터디 모집글 관련 기능(성공/실패 케이스) 테스트 코드 작성

- 모집글 상세 조회 성공
	- 실패: 모집글 없음
- 모집글 조회(검색리스트) 성공
- 모집글 생성 성공
	- 실패: 모집인원 잘못됨, 유저없음, 병행에 위도/경도 값 없음
- 모집글 수정 성공
	- 실패: 모집글 없음
- 모집 마감 성공
	- 실패: 모집글 없음, 모집중이 아님, 승인된 신청자 없음
- 모집 취소 성공
	- 실패: 모집글 없음, 이미 취소됨
- 모집글 자동 취소 성공
- 배치 작업(모집 기한이 지난 모집글 자동 취소 및 삭제) 성공
- 모집 취소된 스터디 모집 기간 연장 성공
	- 실패: 모집글 없음, 취소 상태가 아님, 최대 연장 기간 초과

> ### 테스트
>
> - [x] 테스트 코드
> - [ ] API 테스트