### PR TITLE
스터디 신청 관련 기능(성공/실패 케이스) 테스트 코드 작성

### DIFF
--- a/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
@@ -1,0 +1,64 @@
+package com.devonoff.domain.studySignup.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devonoff.domain.studySignup.dto.StudySignupCreateRequest;
+import com.devonoff.domain.studySignup.dto.StudySignupDto;
+import com.devonoff.domain.studySignup.service.StudySignupService;
+import com.devonoff.type.StudySignupStatus;
+import com.devonoff.util.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StudySignupController.class)
+@AutoConfigureMockMvc(addFilters = false) // Security 필터 비활성화
+class StudySignupControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private StudySignupService studySignupService;
+
+  @MockBean
+  private JwtProvider jwtProvider;
+
+  @Test
+  @DisplayName("스터디 신청 성공")
+  void createStudySignup_Success() throws Exception {
+    // Given
+    StudySignupDto response = StudySignupDto.builder()
+        .signupId(10L)
+        .userId(1L)
+        .nickName("참가자")
+        .status(StudySignupStatus.PENDING)
+        .build();
+
+    when(studySignupService.createStudySignup(any(StudySignupCreateRequest.class)))
+        .thenReturn(response);
+
+    // When & Then
+    mockMvc.perform(post("/api/study-signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"studyPostId\": 100, \"userId\": 1}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.signupId").value(10L))
+        .andExpect(jsonPath("$.userId").value(1L))
+        .andExpect(jsonPath("$.nickName").value("참가자"))
+        .andExpect(jsonPath("$.status").value("PENDING"));
+
+    verify(studySignupService, times(1)).createStudySignup(any(StudySignupCreateRequest.class));
+  }
+}

--- a/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
@@ -1,9 +1,11 @@
 package com.devonoff.domain.studySignup.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -122,5 +124,36 @@ class StudySignupControllerTest {
             .content("{\"studyPostId\": 100, \"userId\": 1}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$").value("이미 해당 스터디에 신청했습니다."));
+  }
+
+  @Test
+  @DisplayName("신청 상태 관리 성공 - 승인")
+  void updateSignupStatus_Approve_Success() throws Exception {
+    // Given
+    Long studySignupId = 1L;
+    StudySignupStatus newStatus = StudySignupStatus.APPROVED;
+
+    // When & Then
+    mockMvc.perform(patch("/api/study-signup/{studySignupId}", studySignupId)
+            .param("newStatus", newStatus.name()))
+        .andExpect(status().isOk());
+
+    verify(studySignupService, times(1)).updateSignupStatus(anyLong(),
+        any(StudySignupStatus.class));
+  }
+
+  @Test
+  @DisplayName("신청 상태 관리 성공 - 취소")
+  void updateSignupStatus_Reject_Success() throws Exception {
+    // Given
+    Long studySignupId = 1L;
+    StudySignupStatus newStatus = StudySignupStatus.REJECTED;
+
+    // When & Then
+    mockMvc.perform(patch("/api/study-signup/{studySignupId}", studySignupId)
+            .param("newStatus", newStatus.name()))
+        .andExpect(status().isOk());
+
+    verify(studySignupService, times(1)).updateSignupStatus(anyLong(), any(StudySignupStatus.class));
   }
 }

--- a/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
@@ -2,10 +2,12 @@ package com.devonoff.domain.studySignup.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -268,5 +270,37 @@ class StudySignupControllerTest {
         .andExpect(jsonPath("$").value("스터디 모집글을 찾을 수 없습니다."));
 
     verify(studySignupService).getSignupList(studyPostId, filterStatus);
+  }
+
+  @Test
+  @DisplayName("신청 취소 성공")
+  void cancelSignup_Success() throws Exception {
+    // Given
+    Long studySignupId = 1L;
+
+    doNothing().when(studySignupService).cancelSignup(studySignupId);
+
+    // When & Then
+    mockMvc.perform(delete("/api/study-signup/{studySignupId}", studySignupId))
+        .andExpect(status().isOk());
+
+    verify(studySignupService).cancelSignup(studySignupId);
+  }
+
+  @Test
+  @DisplayName("신청 취소 실패 - 신청 내역 없음")
+  void cancelSignup_Fail_SignupNotFound() throws Exception {
+    // Given
+    Long studySignupId = 1L;
+
+    doThrow(new CustomException(ErrorCode.SIGNUP_NOT_FOUND))
+        .when(studySignupService).cancelSignup(studySignupId);
+
+    // When & Then
+    mockMvc.perform(delete("/api/study-signup/{studySignupId}", studySignupId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$").value("스터디 신청 내역을 찾을 수 없습니다."));
+
+    verify(studySignupService).cancelSignup(studySignupId);
   }
 }

--- a/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
@@ -11,6 +11,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.devonoff.domain.studySignup.dto.StudySignupCreateRequest;
 import com.devonoff.domain.studySignup.dto.StudySignupDto;
 import com.devonoff.domain.studySignup.service.StudySignupService;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
 import com.devonoff.type.StudySignupStatus;
 import com.devonoff.util.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -60,5 +62,65 @@ class StudySignupControllerTest {
         .andExpect(jsonPath("$.status").value("PENDING"));
 
     verify(studySignupService, times(1)).createStudySignup(any(StudySignupCreateRequest.class));
+  }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 모집글 없음")
+  void createStudySignup_Fail_StudyPostNotFound() throws Exception {
+    // Given
+    when(studySignupService.createStudySignup(any(StudySignupCreateRequest.class)))
+        .thenThrow(new CustomException(ErrorCode.STUDY_POST_NOT_FOUND));
+
+    // When & Then
+    mockMvc.perform(post("/api/study-signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"studyPostId\": 100, \"userId\": 1}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$").value("스터디 모집글을 찾을 수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 모집글이 모집 중이 아님")
+  void createStudySignup_Fail_InvalidStudyStatus() throws Exception {
+    // Given
+    when(studySignupService.createStudySignup(any(StudySignupCreateRequest.class)))
+        .thenThrow(new CustomException(ErrorCode.INVALID_STUDY_STATUS));
+
+    // When & Then
+    mockMvc.perform(post("/api/study-signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"studyPostId\": 100, \"userId\": 1}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$").value("잘못된 스터디 상태값입니다."));
+  }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 유저 없음")
+  void createStudySignup_Fail_UserNotFound() throws Exception {
+    // Given
+    when(studySignupService.createStudySignup(any(StudySignupCreateRequest.class)))
+        .thenThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    // When & Then
+    mockMvc.perform(post("/api/study-signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"studyPostId\": 100, \"userId\": 1}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$").value("사용자를 찾을 수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 이미 해당 스터디에 신청함")
+  void createStudySignup_Fail_DuplicateApplication() throws Exception {
+    // Given
+    when(studySignupService.createStudySignup(any(StudySignupCreateRequest.class)))
+        .thenThrow(new CustomException(ErrorCode.DUPLICATE_APPLICATION));
+
+    // When & Then
+    mockMvc.perform(post("/api/study-signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"studyPostId\": 100, \"userId\": 1}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$").value("이미 해당 스터디에 신청했습니다."));
   }
 }

--- a/src/test/java/com/devonoff/domain/studySignup/service/StudySignupServiceTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/service/StudySignupServiceTest.java
@@ -1,0 +1,86 @@
+package com.devonoff.domain.studySignup.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.devonoff.domain.studyPost.entity.StudyPost;
+import com.devonoff.domain.studyPost.repository.StudyPostRepository;
+import com.devonoff.domain.studySignup.dto.StudySignupCreateRequest;
+import com.devonoff.domain.studySignup.dto.StudySignupDto;
+import com.devonoff.domain.studySignup.entity.StudySignup;
+import com.devonoff.domain.studySignup.repository.StudySignupRepository;
+import com.devonoff.domain.user.entity.User;
+import com.devonoff.domain.user.repository.UserRepository;
+import com.devonoff.domain.user.service.AuthService;
+import com.devonoff.type.StudyPostStatus;
+import com.devonoff.type.StudySignupStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudySignupServiceTest {
+
+  @InjectMocks
+  private StudySignupService studySignupService;
+
+  @Mock
+  private StudyPostRepository studyPostRepository;
+
+  @Mock
+  private StudySignupRepository studySignupRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private AuthService authService;
+
+  @Test
+  @DisplayName("스터디 신청 성공")
+  void createStudySignup_Success() {
+    // Given
+    Long userId = 1L;
+    Long studyPostId = 100L;
+    Long loggedInUserId = 1L;
+
+    StudyPost studyPost = StudyPost.builder()
+        .id(studyPostId)
+        .status(StudyPostStatus.RECRUITING)
+        .build();
+
+    User user = User.builder()
+        .id(userId)
+        .nickname("참가자")
+        .build();
+
+    when(authService.getLoginUserId()).thenReturn(loggedInUserId);
+    when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.of(studyPost));
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(studySignupRepository.existsByStudyPostAndUser(studyPost, user)).thenReturn(false);
+    when(studySignupRepository.save(any(StudySignup.class)))
+        .thenAnswer(invocation -> {
+          StudySignup savedSignup = invocation.getArgument(0);
+          savedSignup.setId(10L);
+          return savedSignup;
+        });
+
+    // When
+    StudySignupDto result = studySignupService.createStudySignup(
+        new StudySignupCreateRequest(studyPostId, userId)
+    );
+
+    // Then
+    assertNotNull(result);
+    assertEquals(10L, result.getSignupId());
+    assertEquals(userId, result.getUserId());
+    assertEquals("참가자", result.getNickName());
+    assertEquals(StudySignupStatus.PENDING, result.getStatus());
+  }
+}

--- a/src/test/java/com/devonoff/domain/studySignup/service/StudySignupServiceTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/service/StudySignupServiceTest.java
@@ -2,6 +2,7 @@ package com.devonoff.domain.studySignup.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -14,6 +15,8 @@ import com.devonoff.domain.studySignup.repository.StudySignupRepository;
 import com.devonoff.domain.user.entity.User;
 import com.devonoff.domain.user.repository.UserRepository;
 import com.devonoff.domain.user.service.AuthService;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
 import com.devonoff.type.StudyPostStatus;
 import com.devonoff.type.StudySignupStatus;
 import java.util.Optional;
@@ -83,4 +86,103 @@ class StudySignupServiceTest {
     assertEquals("참가자", result.getNickName());
     assertEquals(StudySignupStatus.PENDING, result.getStatus());
   }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 모집글 없음")
+  void createStudySignup_Fail_StudyPostNotFound() {
+    // Given
+    Long studyPostId = 100L;
+    Long userId = 1L;
+    Long loggedInUserId = 1L;
+
+    when(authService.getLoginUserId()).thenReturn(loggedInUserId);
+    when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.empty());
+
+    // When & Then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        studySignupService.createStudySignup(new StudySignupCreateRequest(studyPostId, userId))
+    );
+
+    assertEquals(ErrorCode.STUDY_POST_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 모집글이 모집 중이 아님")
+  void createStudySignup_Fail_InvalidStudyStatus() {
+    // Given
+    Long studyPostId = 100L;
+    Long userId = 1L;
+    Long loggedInUserId = 1L;
+
+    StudyPost studyPost = StudyPost.builder()
+        .id(studyPostId)
+        .status(StudyPostStatus.CLOSED) // 모집 종료 상태
+        .build();
+
+    when(authService.getLoginUserId()).thenReturn(loggedInUserId);
+    when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.of(studyPost));
+
+    // When & Then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        studySignupService.createStudySignup(new StudySignupCreateRequest(studyPostId, userId))
+    );
+
+    assertEquals(ErrorCode.INVALID_STUDY_STATUS, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 유저 없음")
+  void createStudySignup_Fail_UserNotFound() {
+    // Given
+    Long studyPostId = 100L;
+    Long userId = 1L;
+    Long loggedInUserId = 1L;
+
+    StudyPost studyPost = StudyPost.builder()
+        .id(studyPostId)
+        .status(StudyPostStatus.RECRUITING)
+        .build();
+
+    when(authService.getLoginUserId()).thenReturn(loggedInUserId);
+    when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.of(studyPost));
+    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+    // When & Then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        studySignupService.createStudySignup(new StudySignupCreateRequest(studyPostId, userId))
+    );
+
+    assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("스터디 신청 실패 - 이미 해당 스터디에 신청함")
+  void createStudySignup_Fail_DuplicateApplication() {
+    // Given
+    Long studyPostId = 100L;
+    Long userId = 1L;
+    Long loggedInUserId = 1L;
+
+    StudyPost studyPost = StudyPost.builder()
+        .id(studyPostId)
+        .status(StudyPostStatus.RECRUITING)
+        .build();
+
+    User user = User.builder()
+        .id(userId)
+        .build();
+
+    when(authService.getLoginUserId()).thenReturn(loggedInUserId);
+    when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.of(studyPost));
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(studySignupRepository.existsByStudyPostAndUser(studyPost, user)).thenReturn(true);
+
+    // When & Then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        studySignupService.createStudySignup(new StudySignupCreateRequest(studyPostId, userId))
+    );
+
+    assertEquals(ErrorCode.DUPLICATE_APPLICATION, exception.getErrorCode());
+  }
+
 }


### PR DESCRIPTION
### Pull Request

> ### 변경사항

> 📌 **AS-IS**

> 🔖 **TO-BE**
### 스터디 신청 관련 기능(성공/실패 케이스) 테스트 코드 작성

- 스터디 신청 성공
	- 실패: 모집글 없음, 모집상태 모집중 아님, 유저 없음, 이미 해당 스터디에 신청
- 신청 상태 관리(승인/거절) 성공
	- 실패: 신청 없음, 모집상태 모집중 아님, 이미 신청 확정된 상태
- 신청 목록 조회 성공
	- 실패: 모집글 없음
- 스터디 신청 취소 성공
	- 실페: 신청 내역 없음

> ### 테스트
>
> - [x] 테스트 코드
> - [ ] API 테스트