### PR TITLE
Refactor: 댓글 서비스 리팩토링 및 인증 로직 분리

### DIFF
--- a/src/main/java/com/devonoff/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/devonoff/domain/comment/dto/CommentRequest.java
@@ -4,14 +4,18 @@ import com.devonoff.domain.comment.entity.Comment;
 import com.devonoff.domain.user.entity.User;
 import com.devonoff.type.PostType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
  // 요청값
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CommentRequest {
 
   private String author;

--- a/src/main/java/com/devonoff/domain/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/devonoff/domain/comment/dto/CommentUpdateRequest.java
@@ -1,14 +1,18 @@
 package com.devonoff.domain.comment.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 // 업데이트 요청값
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentUpdateRequest {
 
   @JsonProperty("is_secret")

--- a/src/main/java/com/devonoff/domain/comment/service/CommentService.java
+++ b/src/main/java/com/devonoff/domain/comment/service/CommentService.java
@@ -5,23 +5,16 @@ import com.devonoff.domain.comment.dto.CommentResponse;
 import com.devonoff.domain.comment.dto.CommentUpdateRequest;
 import com.devonoff.domain.comment.entity.Comment;
 import com.devonoff.domain.comment.repository.CommentRepository;
-import com.devonoff.domain.infosharepost.repository.InfoSharePostRepository;
-import com.devonoff.domain.qnapost.repository.QnaPostRepository;
-import com.devonoff.domain.studyPost.repository.StudyPostRepository;
 import com.devonoff.domain.user.entity.User;
 import com.devonoff.domain.user.repository.UserRepository;
+import com.devonoff.domain.user.service.AuthService;
 import com.devonoff.exception.CustomException;
 import com.devonoff.type.ErrorCode;
 import com.devonoff.type.PostType;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,64 +25,25 @@ public class CommentService {
 
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
+  private final PostValidationService postValidationService;
+  private final AuthService authService;
 
-  private final StudyPostRepository studyPostRepository;
-  private final QnaPostRepository qnaPostRepository;
-  private final InfoSharePostRepository infoSharePostRepository;
-  private final Map<PostType, Object> repositoryMap = new HashMap<>();
 
-  // PostType에 따른 repository를 관리하는 Map
-  @PostConstruct
-  public void initRepositoryMap() {
-    repositoryMap.put(PostType.STUDY, studyPostRepository);
-    repositoryMap.put(PostType.QNA, qnaPostRepository);
-    repositoryMap.put(PostType.INFO, infoSharePostRepository);
-  }
-
-  // 로그인된 사용자 ID 가져오기
-  private Long extractUserIdFromPrincipal() {
-    Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-    if (principal instanceof UserDetails userDetails) {
-      return Long.parseLong(userDetails.getUsername());
-    } else if (principal instanceof String username && !username.equals("anonymousUser")) {
-      return Long.parseLong(username);
-    }
-    throw new CustomException(ErrorCode.USER_NOT_FOUND, "로그인이 필요합니다.");
-  }
-
-  // 게시글 존재 여부 확인
-  public void validatePostExists(PostType postType, Long postId) {
-    Object repository = repositoryMap.get(postType);
-    if (repository == null) {
-      throw new CustomException(ErrorCode.BAD_REQUEST, "잘못된 게시글 타입입니다.");
-    }
-
-    boolean exists = false;
-    if (repository instanceof StudyPostRepository) {
-      exists = ((StudyPostRepository) repository).findById(postId).isPresent();
-    } else if (repository instanceof QnaPostRepository) {
-      exists = ((QnaPostRepository) repository).findById(postId).isPresent();
-    } else if (repository instanceof InfoSharePostRepository) {
-      exists = ((InfoSharePostRepository) repository).findById(postId).isPresent();
-    }
-
-    if (!exists) {
-      throw new CustomException(ErrorCode.POST_NOT_FOUND, "게시글이 존재하지 않습니다.");
-    }
-  }
-
+  /**
+   * 댓글 생성 메서드
+   *
+   * @param commentRequest 댓글 요청 DTO
+   * @return 생성된 댓글 응답 DTO
+   */
   @Transactional
   public CommentResponse createComment(CommentRequest commentRequest) {
+
     // 게시글 존재 여부 검증
-    validatePostExists(commentRequest.getPostType(), commentRequest.getPostId());
+    postValidationService.validatePostExists(commentRequest.getPostType(),
+        commentRequest.getPostId());
 
     // 인증된 사용자 아이디 가져오기
-    Long userId = extractUserIdFromPrincipal();
-
-    // 사용자 정보 조회
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    User user = getAuthenticatedUser();
 
     // Comment 엔티티 생성 및 저장
     Comment comment = commentRequest.toEntity(user);
@@ -99,57 +53,104 @@ public class CommentService {
     return CommentResponse.fromEntity(savedComment);
   }
 
+  /**
+   * 특정 게시글의 댓글 목록 조회
+   *
+   * @param postId   게시글 ID
+   * @param postType 게시글 타입
+   * @param pageable 페이징 정보
+   * @return 페이징된 댓글 응답 DTO
+   */
+
   @Transactional(readOnly = true)
   public Page<CommentResponse> getComments(Long postId, PostType postType, Pageable pageable) {
     // 댓글 페이징 조회
-    Page<Comment> comments = commentRepository.findByPostIdAndPostType(postId, postType, pageable);
-
-    // Comment -> CommentResponse 변환
-    return comments.map(CommentResponse::fromEntity);
+    return commentRepository.findByPostIdAndPostType(postId, postType, pageable)
+        .map(CommentResponse::fromEntity);
   }
+
+  /**
+   * 댓글 수정 메서드
+   *
+   * @param commentId            수정할 댓글 ID
+   * @param commentUpdateRequest 댓글 수정 요청 DTO
+   */
 
   @Transactional
   public void updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest) {
-    // 인증된 사용자 아이디 가져오기
-    Long userId = extractUserIdFromPrincipal();
 
-    // 사용자 조회
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    // 현재인증된 사용자 조회
+    User user = getAuthenticatedUser();
 
-    // 댓글 조회
-    Comment comment = commentRepository.findById(commentId)
-        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, "댓글을 찾을 수 없습니다."));
+    // 댓글ID로 댓글 조회
+    Comment comment = getCommentById(commentId);
 
-    // 작성자 확인
-    if (!comment.getUser().getId().equals(user.getId())) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS);
-    }
+    // 작성자 검증
+    validateCommentOwner(comment, user);
 
     // 수정
     comment.setContent(commentUpdateRequest.getContent());
     comment.setIsSecret(commentUpdateRequest.getIsSecret());
+    // 수정된 내용 저장
     commentRepository.save(comment);
   }
 
   @Transactional
   public void deleteComment(Long commentId) {
-    Long userId = extractUserIdFromPrincipal();
 
-    // 사용자 정보 확인
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    // 현재 인증된 사용자 조회
+    User user = getAuthenticatedUser();
 
-    // 댓글 조회
-    Comment comment = commentRepository.findById(commentId)
-        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, "댓글을 찾을 수 없습니다."));
+    // 댓글 ID로 댓글조회
+    Comment comment = getCommentById(commentId);
 
-    // 작성자 확인
-    if (!comment.getUser().getId().equals(user.getId())) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS, "삭제 권한이 없습니다.");
-    }
+    // 댓글 사용자 검증
+    validateCommentOwner(comment, user);
 
-    // 댓글 삭제
+    // 댓글삭제
     commentRepository.delete(comment);
+
   }
+
+  // Helper Methods
+
+
+  /**
+   * 현재 인증된 사용자 정보 조회
+   *
+   * @return 인증된 사용자 엔티티
+   */
+  private User getAuthenticatedUser() {
+    // SecurityContext에서 사용자 ID 추출
+    Long userId = authService.getLoginUserId();
+
+    // 사용자 ID로 사용자 엔티티 조회
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+  }
+
+  /**
+   * 댓글 ID로 댓글 조회
+   *
+   * @param commentId 댓글 ID
+   * @return 댓글 엔티티
+   */
+  private Comment getCommentById(Long commentId) {
+    return commentRepository.findById(commentId)
+        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, "댓글을 찾을 수 없습니다."));
+  }
+
+  /**
+   * 댓글 작성자 검증
+   *
+   * @param comment 댓글 엔티티
+   * @param user    현재 인증된 사용자
+   */
+  private void validateCommentOwner(Comment comment, User user) {
+    if (!comment.getUser().getId().equals(user.getId())) {
+      throw new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을수 없습니다.");
+    }
+  }
+
 }
+

--- a/src/main/java/com/devonoff/domain/comment/service/PostValidationService.java
+++ b/src/main/java/com/devonoff/domain/comment/service/PostValidationService.java
@@ -1,0 +1,37 @@
+package com.devonoff.domain.comment.service;
+
+
+import com.devonoff.domain.infosharepost.repository.InfoSharePostRepository;
+import com.devonoff.domain.qnapost.repository.QnaPostRepository;
+import com.devonoff.domain.studyPost.repository.StudyPostRepository;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
+import com.devonoff.type.PostType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 댓글 검증서비스 분리
+
+@Service
+@RequiredArgsConstructor
+public class PostValidationService {
+
+  private final StudyPostRepository studyPostRepository;
+  private final QnaPostRepository qnaPostRepository;
+  private final InfoSharePostRepository infoSharePostRepository;
+
+  public void validatePostExists(PostType postType, Long postId) {
+    boolean exists;
+    switch (postType) {
+      case QNA -> exists = qnaPostRepository.existsById(postId);
+      case STUDY -> exists = studyPostRepository.existsById(postId);
+      case INFO -> exists = infoSharePostRepository.existsById(postId);
+      default -> throw new CustomException(ErrorCode.BAD_REQUEST, "잘못된 게시글 타입입니다.");
+    }
+
+    if (!exists) {
+      throw new CustomException(ErrorCode.POST_NOT_FOUND, "게시글이 존재하지 않습니다.");
+    }
+  }
+
+}


### PR DESCRIPTION


> ### 변경사항
> 댓글 서비스 리팩토링 및 인증 로직 분리

> 📌 **AS-IS**
> CommentService 인증및 검증 서비스 존재
> 코드중복으로 가독성 떨어짐 

> 🔖 **TO-BE**
>댓글 관련 검증 로직(validatePostExists)을 별도의 
   PostValidationService로 분리 (단일책임의 원칙)
> 헬퍼 메소드로 코드간결화 

> ### 테스트
> - [ ] 테스트 코드
> - [X] API 테스트