### PR TITLE
이메일 중복 확인 기능 제거 및 엑세스 토큰 재발급 과정 변경

### DIFF
--- a/src/main/java/com/devonoff/domain/user/controller/AuthController.java
+++ b/src/main/java/com/devonoff/domain/user/controller/AuthController.java
@@ -45,20 +45,6 @@ public class AuthController {
   }
 
   /**
-   * 이메일 중복 확인
-   *
-   * @param emailRequest
-   * @return ResponseEntity<Void>
-   */
-  @PostMapping("/check-email")
-  public ResponseEntity<Void> checkEmail(
-      @RequestBody @Valid EmailRequest emailRequest
-  ) {
-    authService.emailCheck(emailRequest);
-    return ResponseEntity.ok().build();
-  }
-
-  /**
    * 인증번호 이메일 전송
    *
    * @param emailSendRequest

--- a/src/main/java/com/devonoff/domain/user/dto/auth/ReissueTokenRequest.java
+++ b/src/main/java/com/devonoff/domain/user/dto/auth/ReissueTokenRequest.java
@@ -1,6 +1,5 @@
 package com.devonoff.domain.user.dto.auth;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,10 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ReissueTokenRequest {
-
-  @Email
-  @NotBlank
-  private String email;
 
   @NotBlank
   private String refreshToken;

--- a/src/main/java/com/devonoff/domain/user/service/AuthService.java
+++ b/src/main/java/com/devonoff/domain/user/service/AuthService.java
@@ -65,15 +65,6 @@ public class AuthService {
   }
 
   /**
-   * 사용자 Email 중복 체크
-   *
-   * @param emailRequest
-   */
-  public void emailCheck(EmailRequest emailRequest) {
-    checkExistsEmail(emailRequest.getEmail());
-  }
-
-  /**
    * 이메일 인증번호 전송
    *
    * @param emailSendRequest

--- a/src/main/java/com/devonoff/domain/user/service/AuthService.java
+++ b/src/main/java/com/devonoff/domain/user/service/AuthService.java
@@ -191,10 +191,12 @@ public class AuthService {
    * @return ReissueTokenResponse
    */
   public ReissueTokenResponse reissueToken(ReissueTokenRequest reissueTokenRequest) {
-    User user = userRepository.findByEmail(reissueTokenRequest.getEmail())
+    Long userId = jwtProvider.getUserId(reissueTokenRequest.getRefreshToken());
+
+    User user = userRepository.findById(userId)
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-    String refreshTokenKey = reissueTokenRequest.getEmail() + "-refreshToken";
+    String refreshTokenKey = user.getEmail() + "-refreshToken";
     String refreshTokenData = authRedisRepository.getData(refreshTokenKey);
 
     if (refreshTokenData == null) {

--- a/src/test/java/com/devonoff/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/devonoff/domain/user/controller/AuthControllerTest.java
@@ -283,7 +283,6 @@ class AuthControllerTest {
   void testReissueToken_Success() throws Exception {
     // given
     ReissueTokenRequest reissueTokenRequest = ReissueTokenRequest.builder()
-        .email("test@email.com")
         .refreshToken("RefreshToken")
         .build();
 
@@ -307,7 +306,6 @@ class AuthControllerTest {
   void testReissueToken_Fail_ValidationFail() throws Exception {
     // given
     ReissueTokenRequest reissueTokenRequest = ReissueTokenRequest.builder()
-        .refreshToken("RefreshToken")
         .build();
 
     // when, then

--- a/src/test/java/com/devonoff/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/devonoff/domain/user/controller/AuthControllerTest.java
@@ -95,35 +95,6 @@ class AuthControllerTest {
   }
 
   @Test
-  @DisplayName("이메일 중복 확인 - 성공")
-  void testCheckEmail_Success() throws Exception {
-    // given
-    EmailRequest emailRequest = EmailRequest.builder()
-        .email("test@email.com")
-        .build();
-    willDoNothing().given(authService).emailCheck(emailRequest);
-
-    // when, then
-    mockMvc.perform(post("/api/auth/check-email")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(emailRequest)))
-        .andExpect(status().isOk());
-  }
-
-  @Test
-  @DisplayName("이메일 중복 확인 - 실패 (유효성 검증 실패)")
-  void testCheckEmail_Fail_ValidationFail() throws Exception {
-    // given
-    EmailRequest emailRequest = EmailRequest.builder().build();
-
-    // when, then
-    mockMvc.perform(post("/api/auth/check-email")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(emailRequest)))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
   @DisplayName("인증번호 이메일 전송 - 성공")
   void testSendEmail_Success() throws Exception {
     // given

--- a/src/test/java/com/devonoff/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/devonoff/domain/user/service/AuthServiceTest.java
@@ -139,43 +139,6 @@ class AuthServiceTest {
   }
 
   @Test
-  @DisplayName("사용자 Email 중복 체크 - 성공")
-  void testEmailCheck_Success() {
-    // given
-    String email = "test@email.com";
-
-    EmailRequest emailRequest = EmailRequest.builder().email(email).build();
-
-    given(userRepository.existsByEmail(eq(email))).willReturn(false);
-
-    // when
-    authService.emailCheck(emailRequest);
-
-    // then
-    verify(userRepository, times(1)).existsByEmail(eq(email));
-  }
-
-  @Test
-  @DisplayName("사용자 Email 중복 체크 - 실패(Email 중복)")
-  void testEmailCheck_Fail_EmailDuplicated() {
-    // given
-    String email = "test@email.com";
-
-    EmailRequest emailRequest = EmailRequest.builder().email(email).build();
-
-    given(userRepository.existsByEmail(eq(email))).willReturn(true);
-
-    // when
-    CustomException customException = assertThrows(CustomException.class,
-        () -> authService.emailCheck(emailRequest));
-
-    // then
-    verify(userRepository, times(1)).existsByEmail(eq(email));
-
-    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.EMAIL_ALREADY_REGISTERED);
-  }
-
-  @Test
   @DisplayName("이메일 인증번호 전송 - 성공")
   void testEmailSend_Success() {
     // given

--- a/src/test/java/com/devonoff/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/devonoff/domain/user/service/AuthServiceTest.java
@@ -602,11 +602,11 @@ class AuthServiceTest {
     String refreshToken = "RefreshToken";
 
     ReissueTokenRequest reissueTokenRequest = ReissueTokenRequest.builder()
-        .email(email)
         .refreshToken(refreshToken)
         .build();
 
     User user = User.builder()
+        .id(1L)
         .nickname("testNickname")
         .email(email)
         .password("encodedPassword")
@@ -614,7 +614,8 @@ class AuthServiceTest {
         .loginType(LoginType.GENERAL)
         .build();
 
-    given(userRepository.findByEmail(eq(email))).willReturn(Optional.of(user));
+    given(jwtProvider.getUserId(eq(refreshToken))).willReturn(1L);
+    given(userRepository.findById(eq(1L))).willReturn(Optional.of(user));
     given(authRedisRepository.getData(eq(email + "-refreshToken"))).willReturn(refreshToken);
     given(jwtProvider.createAccessToken(eq(user.getId()))).willReturn("AccessToken");
 
@@ -622,7 +623,8 @@ class AuthServiceTest {
     ReissueTokenResponse reissueTokenResponse = authService.reissueToken(reissueTokenRequest);
 
     // then
-    verify(userRepository, times(1)).findByEmail(eq(email));
+    verify(jwtProvider, times(1)).getUserId(eq(refreshToken));
+    verify(userRepository, times(1)).findById(eq(1L));
     verify(authRedisRepository, times(1))
         .getData(eq(email + "-refreshToken"));
     verify(jwtProvider, times(1)).createAccessToken(eq(user.getId()));
@@ -634,22 +636,22 @@ class AuthServiceTest {
   @DisplayName("AccessToken 재발급 - 실패 (존재하지 않는 유저)")
   void testReissueToken_Fail_UserNotFound() {
     // given
-    String email = "test@email.com";
     String refreshToken = "RefreshToken";
 
     ReissueTokenRequest reissueTokenRequest = ReissueTokenRequest.builder()
-        .email(email)
         .refreshToken(refreshToken)
         .build();
 
-    given(userRepository.findByEmail(eq(email))).willReturn(Optional.empty());
+    given(jwtProvider.getUserId(eq(refreshToken))).willReturn(1L);
+    given(userRepository.findById(eq(1L))).willReturn(Optional.empty());
 
     // when
     CustomException customException = assertThrows(CustomException.class,
         () -> authService.reissueToken(reissueTokenRequest));
 
     // then
-    verify(userRepository, times(1)).findByEmail(eq(email));
+    verify(jwtProvider, times(1)).getUserId(eq(refreshToken));
+    verify(userRepository, times(1)).findById(eq(1L));
 
     assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
   }
@@ -662,11 +664,11 @@ class AuthServiceTest {
     String refreshToken = "RefreshToken";
 
     ReissueTokenRequest reissueTokenRequest = ReissueTokenRequest.builder()
-        .email(email)
         .refreshToken(refreshToken)
         .build();
 
     User user = User.builder()
+        .id(1L)
         .nickname("testNickname")
         .email(email)
         .password("encodedPassword")
@@ -674,7 +676,8 @@ class AuthServiceTest {
         .loginType(LoginType.GENERAL)
         .build();
 
-    given(userRepository.findByEmail(eq(email))).willReturn(Optional.of(user));
+    given(jwtProvider.getUserId(eq(refreshToken))).willReturn(1L);
+    given(userRepository.findById(eq(1L))).willReturn(Optional.of(user));
     given(authRedisRepository.getData(eq(email + "-refreshToken"))).willReturn(null);
 
     // when
@@ -682,7 +685,8 @@ class AuthServiceTest {
         () -> authService.reissueToken(reissueTokenRequest));
 
     // then
-    verify(userRepository, times(1)).findByEmail(eq(email));
+    verify(jwtProvider, times(1)).getUserId(eq(refreshToken));
+    verify(userRepository, times(1)).findById(eq(1L));
     verify(authRedisRepository, times(1))
         .getData(eq(email + "-refreshToken"));
 
@@ -697,11 +701,11 @@ class AuthServiceTest {
     String refreshToken = "RefreshToken";
 
     ReissueTokenRequest reissueTokenRequest = ReissueTokenRequest.builder()
-        .email(email)
         .refreshToken(refreshToken)
         .build();
 
     User user = User.builder()
+        .id(1L)
         .nickname("testNickname")
         .email(email)
         .password("encodedPassword")
@@ -709,7 +713,8 @@ class AuthServiceTest {
         .loginType(LoginType.GENERAL)
         .build();
 
-    given(userRepository.findByEmail(eq(email))).willReturn(Optional.of(user));
+    given(jwtProvider.getUserId(eq(refreshToken))).willReturn(1L);
+    given(userRepository.findById(eq(1L))).willReturn(Optional.of(user));
     given(authRedisRepository.getData(eq(email + "-refreshToken")))
         .willReturn("refresh-token");
 
@@ -718,7 +723,8 @@ class AuthServiceTest {
         () -> authService.reissueToken(reissueTokenRequest));
 
     // then
-    verify(userRepository, times(1)).findByEmail(eq(email));
+    verify(jwtProvider, times(1)).getUserId(eq(refreshToken));
+    verify(userRepository, times(1)).findById(eq(1L));
     verify(authRedisRepository, times(1))
         .getData(eq(email + "-refreshToken"));
 


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 🔖 **TO-BE**
> - 이메일 중복 확인 기능 제거하고 이메일 인증번호 전송시 이메일 중복기능 확인하도록 변경
> - AccessToken 재발급 진행시 Request Body 에 email 값 받지 않고 발급하도록 변경
> ### 테스트
>
> - [x] 테스트 코드
> - [x] API 테스트