### PR TITLE
로그인된 사용자라면 스터디 신청자 목록 요청 가능하도록 수정, 정보공유, QnA 게시글 삭제시 관련된 댓글 및 대댓글 삭제

### DIFF
--- a/src/main/java/com/devonoff/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/devonoff/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.devonoff.domain.comment.repository;
 
 import com.devonoff.domain.comment.entity.Comment;
 import com.devonoff.type.PostType;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -14,4 +15,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   @EntityGraph(attributePaths = {"replies"})
   Page<Comment> findByPostIdAndPostType(Long postId, PostType postType, Pageable pageable);
 
+  List<Comment> findAllByPostIdAndPostType(Long postId, PostType postType);
+
+  void deleteAllByPostIdAndPostType(Long postId, PostType postType);
 }

--- a/src/main/java/com/devonoff/domain/comment/service/CommentService.java
+++ b/src/main/java/com/devonoff/domain/comment/service/CommentService.java
@@ -62,7 +62,6 @@ public class CommentService {
    * @param pageable 페이징 정보
    * @return 페이징된 댓글 응답 DTO
    */
-
   @Transactional(readOnly = true)
   public Page<CommentResponse> getComments(Long postId, PostType postType, Pageable pageable) {
     // 댓글 페이징 조회
@@ -76,7 +75,6 @@ public class CommentService {
    * @param commentId            수정할 댓글 ID
    * @param commentUpdateRequest 댓글 수정 요청 DTO
    */
-
   @Transactional
   public void updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest) {
 
@@ -96,6 +94,11 @@ public class CommentService {
     commentRepository.save(comment);
   }
 
+  /**
+   * 댓글 삭제
+   *
+   * @param commentId
+   */
   @Transactional
   public void deleteComment(Long commentId) {
 

--- a/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
+++ b/src/main/java/com/devonoff/domain/infosharepost/service/InfoSharePostService.java
@@ -4,15 +4,20 @@ import static com.devonoff.type.ErrorCode.POST_NOT_FOUND;
 import static com.devonoff.type.ErrorCode.UNAUTHORIZED_ACCESS;
 import static com.devonoff.type.ErrorCode.USER_NOT_FOUND;
 
+import com.devonoff.domain.comment.entity.Comment;
+import com.devonoff.domain.comment.repository.CommentRepository;
 import com.devonoff.domain.infosharepost.dto.InfoSharePostDto;
 import com.devonoff.domain.infosharepost.entity.InfoSharePost;
 import com.devonoff.domain.infosharepost.repository.InfoSharePostRepository;
 import com.devonoff.domain.photo.service.PhotoService;
+import com.devonoff.domain.reply.Repository.ReplyRepository;
 import com.devonoff.domain.user.dto.UserDto;
 import com.devonoff.domain.user.entity.User;
 import com.devonoff.domain.user.repository.UserRepository;
 import com.devonoff.domain.user.service.AuthService;
 import com.devonoff.exception.CustomException;
+import com.devonoff.type.PostType;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +37,8 @@ public class InfoSharePostService {
 
   private final InfoSharePostRepository infoSharePostRepository;
   private final UserRepository userRepository;
+  private final CommentRepository commentRepository;
+  private final ReplyRepository replyRepository;
   private final PhotoService photoService;
   private final AuthService authService;
 
@@ -111,6 +118,14 @@ public class InfoSharePostService {
       throw new CustomException(UNAUTHORIZED_ACCESS);
     }
     photoService.delete(infoSharePost.getThumbnailImgUrl());
+    List<Comment> commentList = commentRepository.findAllByPostIdAndPostType(infoPostId,
+        PostType.INFO);
+
+    for (Comment comment : commentList) {
+      replyRepository.deleteAllByComment(comment);
+    }
+
+    commentRepository.deleteAllByPostIdAndPostType(infoPostId, PostType.INFO);
     this.infoSharePostRepository.deleteById(infoPostId);
   }
 }

--- a/src/main/java/com/devonoff/domain/qnapost/service/QnaPostService.java
+++ b/src/main/java/com/devonoff/domain/qnapost/service/QnaPostService.java
@@ -28,8 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class QnaPostService {
 
-  private static final int QNA_PAGE_SIZE = 5;
-
   private final QnaPostRepository qnaPostRepository;
   private final UserRepository userRepository;
   private final PhotoService photoService;
@@ -71,7 +69,7 @@ public class QnaPostService {
   /**
    * 질의 응답 게시글 전체 목록 조회 (최신순) 토큰 X
    *
-   * @param page   조회할 페이지 번호 (1부터 시작)
+   * @param pageable   조회할 페이지 번호 (1부터 시작)
    * @param search 검색 키워드 (optional)
    * @return Page<QnaPostDto>
    */
@@ -91,7 +89,7 @@ public class QnaPostService {
    * 특정 사용자의 질의 응답 게시글 목록 조회 (최신순) 토큰O
    *
    * @param userId
-   * @param page
+   * @param pageable
    * @param search
    * @return Page<QnaPostDto>
    */

--- a/src/main/java/com/devonoff/domain/reply/dto/ReplyResponse.java
+++ b/src/main/java/com/devonoff/domain/reply/dto/ReplyResponse.java
@@ -19,7 +19,7 @@ public class ReplyResponse {
   private PostType postType;
   private Long commentsId;
   private String content;
-  private UserDto userDto;
+  private UserDto user;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
@@ -31,7 +31,7 @@ public class ReplyResponse {
         .postType(reply.getPostType())
         .commentsId(reply.getComment().getId())
         .content(reply.getContent())
-        .userDto(UserDto.fromEntity(reply.getUser()))  // User 엔티티에서 UserDto로 변환
+        .user(UserDto.fromEntity(reply.getUser()))  // User 엔티티에서 UserDto로 변환
         .createdAt(reply.getCreatedAt())
         .updatedAt(reply.getUpdatedAt())
         .build();

--- a/src/main/java/com/devonoff/domain/reply/service/ReplyService.java
+++ b/src/main/java/com/devonoff/domain/reply/service/ReplyService.java
@@ -4,7 +4,6 @@ package com.devonoff.domain.reply.service;
 
 import com.devonoff.domain.comment.entity.Comment;
 import com.devonoff.domain.comment.repository.CommentRepository;
-import com.devonoff.domain.comment.service.CommentService;
 import com.devonoff.domain.reply.Repository.ReplyRepository;
 import com.devonoff.domain.reply.dto.ReplyRequest;
 import com.devonoff.domain.reply.dto.ReplyResponse;

--- a/src/main/java/com/devonoff/domain/student/dto/StudentDto.java
+++ b/src/main/java/com/devonoff/domain/student/dto/StudentDto.java
@@ -1,6 +1,7 @@
 package com.devonoff.domain.student.dto;
 
 import com.devonoff.domain.student.entity.Student;
+import com.devonoff.domain.user.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,14 +15,14 @@ import lombok.Setter;
 public class StudentDto {
 
   private Long studentId;
-  private Long userId;
+  private UserDto user;
   private String nickname;
   private Boolean isLeader;
 
   public static StudentDto fromEntity(Student student) {
     return StudentDto.builder()
         .studentId(student.getId())
-        .userId(student.getUser().getId())
+        .user(UserDto.fromEntity(student.getUser()))
         .nickname(student.getUser().getNickname())
         .isLeader(student.getIsLeader())
         .build();

--- a/src/main/java/com/devonoff/domain/student/dto/StudentDto.java
+++ b/src/main/java/com/devonoff/domain/student/dto/StudentDto.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @Builder
@@ -16,14 +15,12 @@ public class StudentDto {
 
   private Long studentId;
   private UserDto user;
-  private String nickname;
   private Boolean isLeader;
 
   public static StudentDto fromEntity(Student student) {
     return StudentDto.builder()
         .studentId(student.getId())
         .user(UserDto.fromEntity(student.getUser()))
-        .nickname(student.getUser().getNickname())
         .isLeader(student.getIsLeader())
         .build();
   }

--- a/src/main/java/com/devonoff/domain/study/service/StudyService.java
+++ b/src/main/java/com/devonoff/domain/study/service/StudyService.java
@@ -10,7 +10,6 @@ import com.devonoff.domain.studyPost.entity.StudyPost;
 import com.devonoff.domain.studyPost.repository.StudyPostRepository;
 import com.devonoff.domain.totalstudytime.entity.TotalStudyTime;
 import com.devonoff.domain.totalstudytime.repository.TotalStudyTimeRepository;
-import com.devonoff.domain.user.service.AuthService;
 import com.devonoff.exception.CustomException;
 import com.devonoff.type.ErrorCode;
 import com.devonoff.type.StudyStatus;
@@ -33,7 +32,6 @@ public class StudyService {
   private final TotalStudyTimeRepository totalStudyTimeRepository;
   private final StudentRepository studentRepository;
   private final TimeProvider timeProvider;
-  private final AuthService authService;
 
   // 모집글 마감 시 자동으로 스터디 생성
   public Study createStudyFromClosedPost(Long studyPostId) {

--- a/src/main/java/com/devonoff/domain/studyPost/dto/StudyPostDto.java
+++ b/src/main/java/com/devonoff/domain/studyPost/dto/StudyPostDto.java
@@ -2,6 +2,7 @@ package com.devonoff.domain.studyPost.dto;
 
 
 import com.devonoff.domain.studyPost.entity.StudyPost;
+import com.devonoff.domain.user.dto.UserDto;
 import com.devonoff.type.StudyDifficulty;
 import com.devonoff.type.StudyMeetingType;
 import com.devonoff.type.StudyPostStatus;
@@ -44,7 +45,7 @@ public class StudyPostDto {
   private String thumbnailImgUrl;
   private Integer maxParticipants;
   private Integer currentParticipants;
-  private Long userId;
+  private UserDto user;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
@@ -70,7 +71,7 @@ public class StudyPostDto {
         .thumbnailImgUrl(studyPost.getThumbnailImgUrl())
         .maxParticipants(studyPost.getMaxParticipants())
         .currentParticipants(studyPost.getCurrentParticipants())
-        .userId(studyPost.getUser().getId())
+        .user(UserDto.fromEntity(studyPost.getUser()))
         .createdAt(studyPost.getCreatedAt())
         .updatedAt(studyPost.getUpdatedAt())
         .build();

--- a/src/main/java/com/devonoff/domain/studySignup/service/StudySignupService.java
+++ b/src/main/java/com/devonoff/domain/studySignup/service/StudySignupService.java
@@ -78,7 +78,8 @@ public class StudySignupService {
     StudyPost studyPost = studyPostRepository.findById(studyPostId)
         .orElseThrow(() -> new CustomException(ErrorCode.STUDY_POST_NOT_FOUND));
 
-    validateStudyPostOwnership(studyPost.getUser().getId(), authService.getLoginUserId());
+// 로그인된 사용자라면 모두 신청자 목록 요청 가능하도록 수정
+//    validateStudyPostOwnership(studyPost.getUser().getId(), authService.getLoginUserId());
 
     // 상태별 신청 목록 조회
     List<StudySignup> studySignups;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,7 @@ cloud:
     s3:
       bucket: ${S3_BUCKET_NAME}
       default-profile-image-url: https://${S3_BUCKET_NAME}.s3.${S3_REGION}.amazonaws.com/default/default-profile-image.png
+      default-thumbnail-image-url: https://${S3_BUCKET_NAME}.s3.${S3_REGION}.amazonaws.com/default/thumbnail.png
     region:
       static: ${S3_REGION}
     credentials:

--- a/src/test/java/com/devonoff/domain/infosharepost/controller/InfoSharePostControllerTest.java
+++ b/src/test/java/com/devonoff/domain/infosharepost/controller/InfoSharePostControllerTest.java
@@ -1,4 +1,4 @@
-package com.devonoff.infosharepost.controller;
+package com.devonoff.domain.infosharepost.controller;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -50,16 +50,10 @@ class InfoSharePostControllerTest {
     MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg",
         "image content".getBytes());
     InfoSharePostDto mockRequestDto = InfoSharePostDto.builder()
+        .file(file)
         .title("Test Title")
         .description("Test Content")
         .build();
-
-    MockMultipartFile data = new MockMultipartFile(
-        "data",
-        "",
-        "application/json",
-        objectMapper.writeValueAsBytes(mockRequestDto)
-    );
 
     InfoSharePostDto mockResponseDto = InfoSharePostDto.builder()
         .id(1L)
@@ -67,13 +61,12 @@ class InfoSharePostControllerTest {
         .description(mockRequestDto.getDescription())
         .build();
 
-    when(infoSharePostService.createInfoSharePost(mockRequestDto, file)).thenReturn(
+    when(infoSharePostService.createInfoSharePost(mockRequestDto)).thenReturn(
         mockResponseDto);
 
     // When & Then
     mockMvc.perform(multipart("/api/info-posts")
             .file(file)
-            .file(data)
             .contentType(MediaType.MULTIPART_FORM_DATA))
         .andExpect(status().isOk());
   }
@@ -122,17 +115,11 @@ class InfoSharePostControllerTest {
     MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg",
         "image content".getBytes());
     InfoSharePostDto mockRequestDto = InfoSharePostDto.builder()
+        .file(file)
         .title("Updated Title")
         .description("Updated Content")
         .build();
     Long postId = 1L;
-
-    MockMultipartFile data = new MockMultipartFile(
-        "data",
-        "",
-        "application/json",
-        objectMapper.writeValueAsBytes(mockRequestDto)
-    );
 
     InfoSharePostDto mockResponseDto = InfoSharePostDto.builder()
         .id(postId)
@@ -140,13 +127,12 @@ class InfoSharePostControllerTest {
         .description(mockRequestDto.getDescription())
         .build();
 
-    when(infoSharePostService.updateInfoSharePost(postId, mockRequestDto, file)).thenReturn(
+    when(infoSharePostService.updateInfoSharePost(postId, mockRequestDto)).thenReturn(
         mockResponseDto);
 
     // When & Then
     mockMvc.perform(multipart("/api/info-posts/{infoPostId}", postId)
             .file(file)
-            .file(data)
             .contentType(MediaType.MULTIPART_FORM_DATA))
         .andExpect(status().isOk());
   }

--- a/src/test/java/com/devonoff/domain/reply/service/ReplyServiceTest.java
+++ b/src/test/java/com/devonoff/domain/reply/service/ReplyServiceTest.java
@@ -80,6 +80,7 @@ class ReplyServiceTest {
     when(savedReply.getId()).thenReturn(1L); // 저장된 대댓글 ID 반환
     when(savedReply.getContent()).thenReturn(replyRequest.getContent()); // 저장된 대댓글 내용 반환
     when(savedReply.getUser()).thenReturn(loggedInUser); // 저장된 대댓글 작성자 반환
+    when(savedReply.getComment()).thenReturn(parentComment); // 저장된 대댓글 부모 댓글 반환
 
     // 보안 컨텍스트 설정
     mockSecurityContext(userId);
@@ -131,7 +132,6 @@ class ReplyServiceTest {
     SecurityContextHolder.setContext(securityContext);
   }
 
-
   @Test
   @DisplayName("대댓글 수정 성공")
   void testUpdateReplySuccess() {
@@ -146,18 +146,22 @@ class ReplyServiceTest {
 
     Reply existingReply = mock(Reply.class);
     User loggedInUser = mock(User.class);
+    Comment parentComment = mock(Comment.class);
     Reply savedReply = mock(Reply.class);
 
     // Mock 동작 설정
     when(replyRepository.findById(replyId)).thenReturn(Optional.of(existingReply));
     when(existingReply.getUser()).thenReturn(loggedInUser);
+    when(existingReply.getComment()).thenReturn(parentComment); // 기존 댓글의 부모 댓글 설정
     when(loggedInUser.getId()).thenReturn(userId);
+    when(parentComment.getId()).thenReturn(1L); // 부모 댓글 ID 설정
     when(replyRepository.save(any(Reply.class))).thenReturn(savedReply);
 
     // Mock savedReply 필드값 설정
     when(savedReply.getId()).thenReturn(replyId);
     when(savedReply.getContent()).thenReturn("Updated content");
     when(savedReply.getUser()).thenReturn(loggedInUser);
+    when(savedReply.getComment()).thenReturn(parentComment); // 저장된 대댓글의 부모 댓글 설정
 
     mockSecurityContext(userId);
 

--- a/src/test/java/com/devonoff/domain/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/devonoff/domain/study/controller/StudyControllerTest.java
@@ -87,20 +87,18 @@ class StudyControllerTest {
     // Given
     Long studyId = 1L;
 
-    User user1 = User.builder().id(1L).nickname("User1").build();
-    User user2 = User.builder().id(2L).nickname("User2").build();
+    User user1 = User.builder().id(1L).nickname("참가자1").build();
+    User user2 = User.builder().id(2L).nickname("참가자2").build();
 
     StudentDto student1 = StudentDto.builder()
         .studentId(1L)
         .user(UserDto.fromEntity(user1))
-        .nickname("참가자1")
         .isLeader(false)
         .build();
 
     StudentDto student2 = StudentDto.builder()
         .studentId(2L)
         .user(UserDto.fromEntity(user2))
-        .nickname("참가자2")
         .isLeader(false)
         .build();
 
@@ -112,8 +110,8 @@ class StudyControllerTest {
     mockMvc.perform(get("/api/study/{studyId}/participants", studyId))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$", hasSize(2)))
-        .andExpect(jsonPath("$[0].nickname").value("참가자1"))
-        .andExpect(jsonPath("$[1].nickname").value("참가자2"));
+        .andExpect(jsonPath("$[0].user.nickname").value("참가자1"))
+        .andExpect(jsonPath("$[1].user.nickname").value("참가자2"));
 
     verify(studyService, times(1)).getParticipants(studyId);
   }

--- a/src/test/java/com/devonoff/domain/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/devonoff/domain/study/controller/StudyControllerTest.java
@@ -14,6 +14,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.devonoff.domain.student.dto.StudentDto;
 import com.devonoff.domain.study.dto.StudyDto;
 import com.devonoff.domain.study.service.StudyService;
+import com.devonoff.domain.user.dto.UserDto;
+import com.devonoff.domain.user.entity.User;
 import com.devonoff.type.StudyStatus;
 import com.devonoff.util.JwtProvider;
 import java.util.List;
@@ -85,16 +87,19 @@ class StudyControllerTest {
     // Given
     Long studyId = 1L;
 
+    User user1 = User.builder().id(1L).nickname("User1").build();
+    User user2 = User.builder().id(2L).nickname("User2").build();
+
     StudentDto student1 = StudentDto.builder()
         .studentId(1L)
-        .userId(2L)
+        .user(UserDto.fromEntity(user1))
         .nickname("참가자1")
         .isLeader(false)
         .build();
 
     StudentDto student2 = StudentDto.builder()
         .studentId(2L)
-        .userId(3L)
+        .user(UserDto.fromEntity(user2))
         .nickname("참가자2")
         .isLeader(false)
         .build();

--- a/src/test/java/com/devonoff/domain/study/service/StudyServiceTest.java
+++ b/src/test/java/com/devonoff/domain/study/service/StudyServiceTest.java
@@ -79,8 +79,8 @@ class StudyServiceTest {
         .subject(StudySubject.JOB_PREPARATION)
         .difficulty(StudyDifficulty.MEDIUM)
         .dayType(3)
-        .startDate(LocalDate.of(2024, 12, 10))
-        .endDate(LocalDate.of(2024, 12, 20))
+        .startDate(LocalDate.of(2025, 12, 10))
+        .endDate(LocalDate.of(2025, 12, 20))
         .startTime(LocalTime.of(10, 0))
         .endTime(LocalTime.of(12, 0))
         .meetingType(StudyMeetingType.ONLINE)
@@ -102,8 +102,8 @@ class StudyServiceTest {
     assertEquals(StudySubject.JOB_PREPARATION, result.getSubject());
     assertEquals(StudyDifficulty.MEDIUM, result.getDifficulty());
     assertEquals(3, result.getDayType());
-    assertEquals(LocalDate.of(2024, 12, 10), result.getStartDate());
-    assertEquals(LocalDate.of(2024, 12, 20), result.getEndDate());
+    assertEquals(LocalDate.of(2025, 12, 10), result.getStartDate());
+    assertEquals(LocalDate.of(2025, 12, 20), result.getEndDate());
     assertEquals(LocalTime.of(10, 0), result.getStartTime());
     assertEquals(LocalTime.of(12, 0), result.getEndTime());
     assertEquals(StudyMeetingType.ONLINE, result.getMeetingType());

--- a/src/test/java/com/devonoff/domain/study/service/StudyServiceTest.java
+++ b/src/test/java/com/devonoff/domain/study/service/StudyServiceTest.java
@@ -250,8 +250,8 @@ class StudyServiceTest {
     // Then
     assertNotNull(result);
     assertEquals(2, result.size());
-    assertEquals("참가자1", result.get(0).getNickname());
-    assertEquals("참가자2", result.get(1).getNickname());
+    assertEquals("참가자1", result.get(0).getUser().getNickname());
+    assertEquals("참가자2", result.get(1).getUser().getNickname());
   }
 
   @DisplayName("스터디 상태 자동 업데이트")

--- a/src/test/java/com/devonoff/domain/studyPost/service/StudyPostServiceTest.java
+++ b/src/test/java/com/devonoff/domain/studyPost/service/StudyPostServiceTest.java
@@ -133,7 +133,7 @@ class StudyPostServiceTest {
     assertEquals(35.6895, result.getLatitude());
     assertEquals(139.6917, result.getLongitude());
     assertEquals(5, result.getMaxParticipants());
-    assertEquals(11L, result.getUserId());
+    assertEquals(11L, result.getUser().getId());
   }
 
   @DisplayName("스터디 모집글 상세 조회 실패 - 모집글 없음")
@@ -338,7 +338,7 @@ class StudyPostServiceTest {
     Assertions.assertEquals(request.getMeetingType(), result.getMeetingType());
     Assertions.assertEquals(request.getRecruitmentPeriod(), result.getRecruitmentPeriod());
     Assertions.assertEquals(request.getDescription(), result.getDescription());
-    Assertions.assertEquals(loggedInUserId, result.getUserId());
+    Assertions.assertEquals(loggedInUserId, result.getUser().getId());
     Assertions.assertEquals("mock_thumbnail_url", result.getThumbnailImgUrl());
 
     verify(authService, times(1)).getLoginUserId();
@@ -459,6 +459,7 @@ class StudyPostServiceTest {
     // Given
     Long studyPostId = 1L;
     Long loggedInUserId = 1L;
+    MultipartFile file = mock(MultipartFile.class);
 
     User user = new User();
     user.setId(loggedInUserId);
@@ -483,12 +484,14 @@ class StudyPostServiceTest {
         .latitude(37.5665)
         .longitude(126.9780)
         .status(StudyPostStatus.RECRUITING)
+        .file(file)
         .thumbnailImgUrl("updated_thumbnail_url")
         .maxParticipants(10)
         .build();
 
     when(authService.getLoginUserId()).thenReturn(loggedInUserId);
     when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.of(studyPost));
+    when(photoService.save(file)).thenReturn("updated_thumbnail_url");
     when(studyPostRepository.save(any(StudyPost.class))).thenAnswer(
         invocation -> invocation.getArgument(0));
 

--- a/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/controller/StudySignupControllerTest.java
@@ -51,7 +51,7 @@ class StudySignupControllerTest {
     StudySignupDto response = StudySignupDto.builder()
         .signupId(10L)
         .userId(1L)
-        .nickName("참가자")
+        .nickname("참가자")
         .status(StudySignupStatus.PENDING)
         .build();
 
@@ -65,7 +65,7 @@ class StudySignupControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.signupId").value(10L))
         .andExpect(jsonPath("$.userId").value(1L))
-        .andExpect(jsonPath("$.nickName").value("참가자"))
+        .andExpect(jsonPath("$.nickname").value("참가자"))
         .andExpect(jsonPath("$.status").value("PENDING"));
 
     verify(studySignupService, times(1)).createStudySignup(any(StudySignupCreateRequest.class));
@@ -83,7 +83,8 @@ class StudySignupControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("{\"studyPostId\": 100, \"userId\": 1}"))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$").value("스터디 모집글을 찾을 수 없습니다."));
+        .andExpect(jsonPath("$.errorCode").value("STUDY_POST_NOT_FOUND"))
+        .andExpect(jsonPath("$.errorMessage").value("스터디 모집글을 찾을 수 없습니다."));
   }
 
   @Test
@@ -98,7 +99,8 @@ class StudySignupControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("{\"studyPostId\": 100, \"userId\": 1}"))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$").value("잘못된 스터디 상태값입니다."));
+        .andExpect(jsonPath("$.errorCode").value("INVALID_STUDY_STATUS"))
+        .andExpect(jsonPath("$.errorMessage").value("잘못된 스터디 상태값입니다."));
   }
 
   @Test
@@ -113,7 +115,8 @@ class StudySignupControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("{\"studyPostId\": 100, \"userId\": 1}"))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$").value("사용자를 찾을 수 없습니다."));
+        .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"))
+        .andExpect(jsonPath("$.errorMessage").value("사용자를 찾을 수 없습니다."));
   }
 
   @Test
@@ -128,7 +131,8 @@ class StudySignupControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("{\"studyPostId\": 100, \"userId\": 1}"))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$").value("이미 해당 스터디에 신청했습니다."));
+        .andExpect(jsonPath("$.errorCode").value("DUPLICATE_APPLICATION"))
+        .andExpect(jsonPath("$.errorMessage").value("이미 해당 스터디에 신청했습니다."));
   }
 
   @Test
@@ -177,7 +181,8 @@ class StudySignupControllerTest {
     mockMvc.perform(patch("/api/study-signup/{studySignupId}", studySignupId)
             .param("newStatus", newStatus.name()))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$").value("스터디 신청 내역을 찾을 수 없습니다."));
+        .andExpect(jsonPath("$.errorCode").value("SIGNUP_NOT_FOUND"))
+        .andExpect(jsonPath("$.errorMessage").value("스터디 신청 내역을 찾을 수 없습니다."));
   }
 
   @Test
@@ -194,7 +199,8 @@ class StudySignupControllerTest {
     mockMvc.perform(patch("/api/study-signup/{studySignupId}", studySignupId)
             .param("newStatus", newStatus.name()))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$").value("잘못된 스터디 상태값입니다."));
+        .andExpect(jsonPath("$.errorCode").value("INVALID_STUDY_STATUS"))
+        .andExpect(jsonPath("$.errorMessage").value("잘못된 스터디 상태값입니다."));
   }
 
   @Test
@@ -211,7 +217,8 @@ class StudySignupControllerTest {
     mockMvc.perform(patch("/api/study-signup/{studySignupId}", studySignupId)
             .param("newStatus", newStatus.name()))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$").value("이미 확정된 신청 상태입니다."));
+        .andExpect(jsonPath("$.errorCode").value("SIGNUP_STATUS_ALREADY_FINALIZED"))
+        .andExpect(jsonPath("$.errorMessage").value("이미 확정된 신청 상태입니다."));
   }
 
   @Test
@@ -225,13 +232,13 @@ class StudySignupControllerTest {
         StudySignupDto.builder()
             .signupId(10L)
             .userId(101L)
-            .nickName("참가자1")
+            .nickname("참가자1")
             .status(StudySignupStatus.PENDING)
             .build(),
         StudySignupDto.builder()
             .signupId(11L)
             .userId(102L)
-            .nickName("참가자2")
+            .nickname("참가자2")
             .status(StudySignupStatus.PENDING)
             .build()
     );
@@ -245,9 +252,9 @@ class StudySignupControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.size()").value(2))
         .andExpect(jsonPath("$[0].signupId").value(10L))
-        .andExpect(jsonPath("$[0].nickName").value("참가자1"))
+        .andExpect(jsonPath("$[0].nickname").value("참가자1"))
         .andExpect(jsonPath("$[1].signupId").value(11L))
-        .andExpect(jsonPath("$[1].nickName").value("참가자2"));
+        .andExpect(jsonPath("$[1].nickname").value("참가자2"));
 
     verify(studySignupService).getSignupList(studyPostId, filterStatus);
   }
@@ -267,7 +274,8 @@ class StudySignupControllerTest {
             .param("studyPostId", studyPostId.toString())
             .param("status", filterStatus.name()))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$").value("스터디 모집글을 찾을 수 없습니다."));
+        .andExpect(jsonPath("$.errorCode").value("STUDY_POST_NOT_FOUND"))
+        .andExpect(jsonPath("$.errorMessage").value("스터디 모집글을 찾을 수 없습니다."));
 
     verify(studySignupService).getSignupList(studyPostId, filterStatus);
   }
@@ -299,7 +307,8 @@ class StudySignupControllerTest {
     // When & Then
     mockMvc.perform(delete("/api/study-signup/{studySignupId}", studySignupId))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$").value("스터디 신청 내역을 찾을 수 없습니다."));
+        .andExpect(jsonPath("$.errorCode").value("SIGNUP_NOT_FOUND"))
+        .andExpect(jsonPath("$.errorMessage").value("스터디 신청 내역을 찾을 수 없습니다."));
 
     verify(studySignupService).cancelSignup(studySignupId);
   }

--- a/src/test/java/com/devonoff/domain/studySignup/service/StudySignupServiceTest.java
+++ b/src/test/java/com/devonoff/domain/studySignup/service/StudySignupServiceTest.java
@@ -86,7 +86,7 @@ class StudySignupServiceTest {
     assertNotNull(result);
     assertEquals(10L, result.getSignupId());
     assertEquals(userId, result.getUserId());
-    assertEquals("참가자", result.getNickName());
+    assertEquals("참가자", result.getNickname());
     assertEquals(StudySignupStatus.PENDING, result.getStatus());
   }
 
@@ -367,7 +367,7 @@ class StudySignupServiceTest {
     List<StudySignup> studySignups = List.of(signup1, signup2);
 
     when(studyPostRepository.findById(studyPostId)).thenReturn(Optional.of(studyPost));
-    when(authService.getLoginUserId()).thenReturn(loggedInUserId);
+//    when(authService.getLoginUserId()).thenReturn(loggedInUserId);
     when(studySignupRepository.findByStudyPostAndStatus(studyPost, filterStatus)).thenReturn(
         studySignups);
 
@@ -377,10 +377,10 @@ class StudySignupServiceTest {
     // Then
     assertNotNull(result);
     assertEquals(2, result.size());
-    assertEquals("참가자1", result.get(0).getNickName());
-    assertEquals("참가자2", result.get(1).getNickName());
+    assertEquals("참가자1", result.get(0).getNickname());
+    assertEquals("참가자2", result.get(1).getNickname());
     verify(studyPostRepository).findById(studyPostId);
-    verify(authService).getLoginUserId();
+//    verify(authService).getLoginUserId();
     verify(studySignupRepository).findByStudyPostAndStatus(studyPost, filterStatus);
   }
 

--- a/src/test/java/com/devonoff/domain/studytimeline/controller/StudyTimelineControllerTest.java
+++ b/src/test/java/com/devonoff/domain/studytimeline/controller/StudyTimelineControllerTest.java
@@ -1,4 +1,4 @@
-package com.devonoff.studytimeline.controller;
+package com.devonoff.domain.studytimeline.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/test/java/com/devonoff/domain/studytimeline/service/StudyTimelineServiceTest.java
+++ b/src/test/java/com/devonoff/domain/studytimeline/service/StudyTimelineServiceTest.java
@@ -1,4 +1,4 @@
-package com.devonoff.studytimeline.service;
+package com.devonoff.domain.studytimeline.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/devonoff/domain/totalstudytime/controller/TotalStudyTimeControllerTest.java
+++ b/src/test/java/com/devonoff/domain/totalstudytime/controller/TotalStudyTimeControllerTest.java
@@ -1,4 +1,4 @@
-package com.devonoff.totalstudytime.controller;
+package com.devonoff.domain.totalstudytime.controller;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/test/java/com/devonoff/domain/totalstudytime/service/TotalStudyTimeServiceTest.java
+++ b/src/test/java/com/devonoff/domain/totalstudytime/service/TotalStudyTimeServiceTest.java
@@ -1,4 +1,4 @@
-package com.devonoff.totalstudytime.service;
+package com.devonoff.domain.totalstudytime.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 🔖 **TO-BE**
> - 응답시 userId 대신 user 객체 정보 응답
> - 코드 정리
> - 로그인된 사용자라면 스터디 신청자 목록 요청 가능하도록 수정
> - QnA 게시글 삭제시 관련된 댓글 및 대댓글 삭제
> - 변경사항에 대한 테스트코드 작성
>    - 신청 목록을 로그인된 사용자면 요청 할 수 있도록 수정한 것에 대한 테스트 코드
>    - userId 로 유저정보를 응답하던 것을 user 객체로 응답하도록 수정한 것에 대한 테스트 코드
>    - 정보공유, QnA 게시글 삭제시 관련된 댓글, 대댓글 삭제에 대한 테스트 코드 작성

> ### 테스트
>
> - [x] 테스트 코드
> - [x] API 테스트