### PR TITLE
채팅 기능 코드 수정 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/devonoff/config/WebSocketConfiguration.java
+++ b/src/main/java/com/devonoff/config/WebSocketConfiguration.java
@@ -21,7 +21,8 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     registry.addEndpoint("/signaling").setAllowedOriginPatterns("*")
         .withSockJS();
 
-    registry.addEndpoint("/ws").setAllowedOriginPatterns("*")
+    registry.addEndpoint("/ws")
+        .setAllowedOriginPatterns("http://localhost:3000")
         .withSockJS();
   }
 }

--- a/src/main/java/com/devonoff/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/devonoff/domain/chat/controller/ChatRoomController.java
@@ -4,14 +4,15 @@ import com.devonoff.domain.chat.dto.ChatMessageDto;
 import com.devonoff.domain.chat.dto.ChatRoomDto;
 import com.devonoff.domain.chat.service.ChatMessageService;
 import com.devonoff.domain.chat.service.ChatRoomService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -44,8 +45,11 @@ public class ChatRoomController {
    * @return ResponseEntity<List<ChatMessageDto>>
    */
   @GetMapping("/{chatRoomId}/messages")
-  public ResponseEntity<List<ChatMessageDto>> getChatMessages(@PathVariable Long chatRoomId) {
-    return ResponseEntity.ok(chatMessageService.getChatMessages(chatRoomId));
+  public ResponseEntity<Page<ChatMessageDto>> getChatMessages(
+      @PathVariable Long chatRoomId,
+      @RequestParam(required = false, defaultValue = "0") Integer page
+  ) {
+    return ResponseEntity.ok(chatMessageService.getChatMessages(chatRoomId, page));
   }
 
 }

--- a/src/main/java/com/devonoff/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/devonoff/domain/chat/dto/ChatMessageDto.java
@@ -17,14 +17,14 @@ import lombok.NoArgsConstructor;
 public class ChatMessageDto {
 
   private Long id;
-  private UserDto sender;
+  private UserDto user;
   private String content;
   private LocalDateTime createdAt;
 
   public static ChatMessageDto fromEntity(ChatMessage chatMessage) {
     return ChatMessageDto.builder()
         .id(chatMessage.getId())
-        .sender(UserDto.fromEntity(chatMessage.getSender()))
+        .user(UserDto.fromEntity(chatMessage.getSender()))
         .content(chatMessage.getContent())
         .createdAt(getKoreaTime(chatMessage.getCreatedAt()))
         .build();

--- a/src/main/java/com/devonoff/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/devonoff/domain/chat/repository/ChatMessageRepository.java
@@ -2,13 +2,14 @@ package com.devonoff.domain.chat.repository;
 
 import com.devonoff.domain.chat.entity.ChatMessage;
 import com.devonoff.domain.chat.entity.ChatRoom;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-  List<ChatMessage> findAllByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom);
+  Page<ChatMessage> findAllByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom, Pageable pageable);
 
 }

--- a/src/main/java/com/devonoff/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/devonoff/domain/chat/repository/ChatMessageRepository.java
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-  Page<ChatMessage> findAllByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom, Pageable pageable);
+  Page<ChatMessage> findAllByChatRoom(ChatRoom chatRoom, Pageable pageable);
 
 }

--- a/src/main/java/com/devonoff/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/devonoff/domain/chat/service/ChatMessageService.java
@@ -84,7 +84,7 @@ public class ChatMessageService {
 
     Pageable pageable = PageRequest.of(page, 20, Sort.by("createdAt").descending());
 
-    return chatMessageRepository.findAllByChatRoomOrderByCreatedAtAsc(chatRoom, pageable)
+    return chatMessageRepository.findAllByChatRoom(chatRoom, pageable)
         .map(ChatMessageDto::fromEntity);
   }
 }

--- a/src/main/java/com/devonoff/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/devonoff/domain/chat/service/ChatMessageService.java
@@ -13,8 +13,11 @@ import com.devonoff.domain.user.service.AuthService;
 import com.devonoff.exception.CustomException;
 import com.devonoff.type.ErrorCode;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -67,7 +70,7 @@ public class ChatMessageService {
    * @param chatRoomId
    * @return List<ChatMessageDto>
    */
-  public List<ChatMessageDto> getChatMessages(Long chatRoomId) {
+  public Page<ChatMessageDto> getChatMessages(Long chatRoomId, Integer page) {
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
         .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
@@ -79,9 +82,9 @@ public class ChatMessageService {
       throw new CustomException(ErrorCode.DOES_NOT_STUDENT_OF_STUDY);
     }
 
-    return chatMessageRepository.findAllByChatRoomOrderByCreatedAtAsc(chatRoom)
-        .stream()
-        .map(ChatMessageDto::fromEntity)
-        .toList();
+    Pageable pageable = PageRequest.of(page, 20, Sort.by("createdAt").descending());
+
+    return chatMessageRepository.findAllByChatRoomOrderByCreatedAtAsc(chatRoom, pageable)
+        .map(ChatMessageDto::fromEntity);
   }
 }

--- a/src/test/java/com/devonoff/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/devonoff/domain/chat/controller/ChatRoomControllerTest.java
@@ -1,0 +1,191 @@
+package com.devonoff.domain.chat.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devonoff.config.SecurityConfig;
+import com.devonoff.domain.chat.dto.ChatMessageDto;
+import com.devonoff.domain.chat.dto.ChatRoomDto;
+import com.devonoff.domain.chat.entity.ChatMessage;
+import com.devonoff.domain.chat.entity.ChatRoom;
+import com.devonoff.domain.chat.service.ChatMessageService;
+import com.devonoff.domain.chat.service.ChatRoomService;
+import com.devonoff.domain.study.entity.Study;
+import com.devonoff.domain.user.entity.User;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
+import com.devonoff.util.JwtProvider;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ChatRoomController.class)
+@Import(SecurityConfig.class) // SecurityConfig를 명시적으로 포함 (Optional)
+@AutoConfigureMockMvc(addFilters = false)
+class ChatRoomControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  JwtProvider jwtProvider;
+
+  @MockBean
+  private ChatRoomService chatRoomService;
+
+  @MockBean
+  private ChatMessageService chatMessageService;
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 성공")
+  void testEnterChatRoom_Success() throws Exception {
+    // Given
+    Long studyId = 1L;
+    Long userId = 1L;
+    ChatRoomDto chatRoomDto =
+        ChatRoomDto.builder().chatRoomId(1L).studyId(1L).studyName("Test Study").build();
+
+    Mockito.when(chatRoomService.getOrCreateChatRoom(studyId, userId)).thenReturn(chatRoomDto);
+
+    // When & Then
+    mockMvc.perform(post("/api/chat/study/{studyId}/participant/{userId}", studyId, userId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 실패 (로그인한 유저와 불일치)")
+  void testEnterChatRoom_Fail_UnAuthorizedUser() throws Exception {
+    // Given
+    Long studyId = 1L;
+    Long userId = 1L;
+
+    Mockito.when(chatRoomService.getOrCreateChatRoom(studyId, userId))
+        .thenThrow(new CustomException(ErrorCode.UNAUTHORIZED_USER));
+
+    // When & Then
+    mockMvc.perform(post("/api/chat/study/{studyId}/participant/{userId}", studyId, userId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 실패 (존재하지 않는 스터디)")
+  void testEnterChatRoom_Fail_DoesNotStudentOfStudy() throws Exception {
+    // Given
+    Long studyId = 1L;
+    Long userId = 1L;
+
+    Mockito.when(chatRoomService.getOrCreateChatRoom(studyId, userId))
+        .thenThrow(new CustomException(ErrorCode.DOES_NOT_STUDENT_OF_STUDY));
+
+    // When & Then
+    mockMvc.perform(post("/api/chat/study/{studyId}/participant/{userId}", studyId, userId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 실패 (해당 스터디 참여자가 아닌 경우)")
+  void testEnterChatRoom_Fail_StudyNotFound() throws Exception {
+    // Given
+    Long studyId = 1L;
+    Long userId = 1L;
+
+    Mockito.when(chatRoomService.getOrCreateChatRoom(studyId, userId))
+        .thenThrow(new CustomException(ErrorCode.STUDY_NOT_FOUND));
+
+    // When & Then
+    mockMvc.perform(post("/api/chat/study/{studyId}/participant/{userId}", studyId, userId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 내역 조회 - 성공")
+  void testGetChatMessages_Success() throws Exception {
+    // Given
+    Long chatRoomId = 1L;
+
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+    User user = User.builder().id(1L).build();
+
+    List<ChatMessage> chatMessageList = List.of(
+        ChatMessage.builder()
+            .id(1L)
+            .content("Test Message 1")
+            .createdAt(LocalDateTime.now())
+            .sender(user)
+            .chatRoom(chatRoom)
+            .build(),
+        ChatMessage.builder()
+            .id(2L)
+            .content("Test Message 2")
+            .createdAt(LocalDateTime.now())
+            .sender(user)
+            .chatRoom(chatRoom)
+            .build(),
+        ChatMessage.builder()
+            .id(3L)
+            .content("Test Message 3")
+            .createdAt(LocalDateTime.now())
+            .sender(user)
+            .chatRoom(chatRoom)
+            .build()
+    );
+
+    Page<ChatMessage> chatMessagePage = new PageImpl<>(chatMessageList);
+    Page<ChatMessageDto> responseChatMessages = chatMessagePage.map(ChatMessageDto::fromEntity);
+
+    Mockito.when(chatMessageService.getChatMessages(chatRoomId, 0)).thenReturn(responseChatMessages);
+
+    // When & Then
+    mockMvc.perform(get("/api/chat/{chatRoomId}/messages", chatRoomId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 내역 조회 - 실패 (존재하지 않는 채팅방)")
+  void testGetChatMessages_Fail_ChatRoomNotFound() throws Exception {
+    // Given
+    Long chatRoomId = 1L;
+
+    Mockito.when(chatMessageService.getChatMessages(chatRoomId, 0))
+        .thenThrow(new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+    // When & Then
+    mockMvc.perform(get("/api/chat/{chatRoomId}/messages", chatRoomId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 내역 조회 - 실패 (해당 스터디 참여자가 아닌 경우)")
+  void testGetChatMessages_Fail_DoesNotStudentOfStudy() throws Exception {
+    // Given
+    Long chatRoomId = 1L;
+
+    Mockito.when(chatMessageService.getChatMessages(chatRoomId, 0))
+        .thenThrow(new CustomException(ErrorCode.DOES_NOT_STUDENT_OF_STUDY));
+
+    // When & Then
+    mockMvc.perform(get("/api/chat/{chatRoomId}/messages", chatRoomId)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+}

--- a/src/test/java/com/devonoff/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/devonoff/domain/chat/service/ChatMessageServiceTest.java
@@ -1,0 +1,300 @@
+package com.devonoff.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.devonoff.domain.chat.dto.ChatMessageDto;
+import com.devonoff.domain.chat.dto.ChatMessageRequest;
+import com.devonoff.domain.chat.entity.ChatMessage;
+import com.devonoff.domain.chat.entity.ChatRoom;
+import com.devonoff.domain.chat.repository.ChatMessageRepository;
+import com.devonoff.domain.chat.repository.ChatRoomRepository;
+import com.devonoff.domain.student.repository.StudentRepository;
+import com.devonoff.domain.study.entity.Study;
+import com.devonoff.domain.user.entity.User;
+import com.devonoff.domain.user.repository.UserRepository;
+import com.devonoff.domain.user.service.AuthService;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+  @InjectMocks
+  private ChatMessageService chatMessageService;
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  private ChatMessageRepository chatMessageRepository;
+
+  @Mock
+  private StudentRepository studentRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private AuthService authService;
+
+  @Test
+  @DisplayName("채팅 메시지 저장 - 성공")
+  void testCreateChatMessage_Success() {
+    // given
+    Long chatRoomId = 1L;
+    Long senderId = 1L;
+    ChatMessageRequest chatMessageRequest = ChatMessageRequest.builder()
+        .senderId(1L)
+        .content("Test Message")
+        .build();
+
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+    User user = User.builder().id(1L).build();
+    ChatMessage chatMessage = ChatMessage.builder()
+        .id(1L)
+        .chatRoom(chatRoom)
+        .sender(user)
+        .content("Test Message")
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.of(chatRoom));
+    given(studentRepository.existsByUserIdAndStudyId(eq(senderId), eq(chatRoom.getStudy().getId())))
+        .willReturn(true);
+    given(userRepository.findById(eq(senderId))).willReturn(Optional.of(user));
+    given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(chatMessage);
+
+    // when
+    ChatMessageDto chatMessageDto = chatMessageService.createChatMessage(chatRoomId,
+        chatMessageRequest);
+
+    // then
+    verify(chatRoomRepository, times(1)).findById(eq(chatRoomId));
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(senderId), eq(chatRoom.getStudy().getId()));
+    verify(userRepository, times(1)).findById(eq(senderId));
+    verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+
+    assertThat(chatMessageDto.getId()).isEqualTo(1L);
+    assertThat(chatMessageDto.getUser().getId()).isEqualTo(1L);
+    assertThat(chatMessageDto.getContent()).isEqualTo("Test Message");
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 저장 - 실패 (존재하지 않는 채팅방)")
+  void testCreateChatMessage_Fail_ChatRoomNotFound() {
+    // given
+    Long chatRoomId = 1L;
+    Long senderId = 1L;
+    ChatMessageRequest chatMessageRequest = ChatMessageRequest.builder()
+        .senderId(1L)
+        .content("Test Message")
+        .build();
+
+    given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.empty());
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatMessageService.createChatMessage(chatRoomId, chatMessageRequest));
+
+    // then
+    verify(chatRoomRepository, times(1)).findById(eq(chatRoomId));
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND);
+    assertThat(customException.getErrorMessage()).isEqualTo("채팅방을 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 저장 - 실패 (해당 스터디 참여자가 아닌 경우)")
+  void testCreateChatMessage_Fail_DoesNotStudentOfStudy() {
+    // given
+    Long chatRoomId = 1L;
+    Long senderId = 1L;
+    ChatMessageRequest chatMessageRequest = ChatMessageRequest.builder()
+        .senderId(1L)
+        .content("Test Message")
+        .build();
+
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+
+    given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.of(chatRoom));
+    given(studentRepository.existsByUserIdAndStudyId(eq(senderId), eq(chatRoom.getStudy().getId())))
+        .willReturn(false);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatMessageService.createChatMessage(chatRoomId, chatMessageRequest));
+
+    // then
+    verify(chatRoomRepository, times(1)).findById(eq(chatRoomId));
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(senderId), eq(chatRoom.getStudy().getId()));
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.DOES_NOT_STUDENT_OF_STUDY);
+    assertThat(customException.getErrorMessage()).isEqualTo("해당 스터디 참가자가 아닙니다.");
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 저장 - 실패 (존재하지 않는 유저)")
+  void testCreateChatMessage_Fail_UserNotFound() {
+    // given
+    Long chatRoomId = 1L;
+    Long senderId = 1L;
+    ChatMessageRequest chatMessageRequest = ChatMessageRequest.builder()
+        .senderId(1L)
+        .content("Test Message")
+        .build();
+
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+
+    given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.of(chatRoom));
+    given(studentRepository.existsByUserIdAndStudyId(eq(senderId), eq(chatRoom.getStudy().getId())))
+        .willReturn(true);
+    given(userRepository.findById(eq(senderId))).willReturn(Optional.empty());
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatMessageService.createChatMessage(chatRoomId, chatMessageRequest));
+
+    // then
+    verify(chatRoomRepository, times(1)).findById(eq(chatRoomId));
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(senderId), eq(chatRoom.getStudy().getId()));
+    verify(userRepository, times(1)).findById(eq(senderId));
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+    assertThat(customException.getErrorMessage()).isEqualTo("사용자를 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 내역 조회 - 성공")
+  void testGetChatMessages_Success() {
+    // given
+    Long chatRoomId = 1L;
+    Long loginUserId = 1L;
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
+
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+    User user = User.builder().id(1L).build();
+
+    List<ChatMessage> chatMessageList = List.of(
+        ChatMessage.builder()
+            .id(1L)
+            .content("Test Message 1")
+            .createdAt(LocalDateTime.now())
+            .sender(user)
+            .chatRoom(chatRoom)
+            .build(),
+        ChatMessage.builder()
+            .id(2L)
+            .content("Test Message 2")
+            .createdAt(LocalDateTime.now())
+            .sender(user)
+            .chatRoom(chatRoom)
+            .build(),
+        ChatMessage.builder()
+            .id(3L)
+            .content("Test Message 3")
+            .createdAt(LocalDateTime.now())
+            .sender(user)
+            .chatRoom(chatRoom)
+            .build()
+    );
+
+    Page<ChatMessage> chatMessagePage = new PageImpl<>(chatMessageList);
+
+    given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.of(chatRoom));
+    given(authService.getLoginUserId()).willReturn(1L);
+    given(studentRepository.existsByUserIdAndStudyId(eq(loginUserId), eq(chatRoomId)))
+        .willReturn(true);
+    given(chatMessageRepository.findAllByChatRoom(eq(chatRoom), eq(pageable)))
+        .willReturn(chatMessagePage);
+
+    // when
+    Page<ChatMessageDto> responseChatMessages = chatMessageService.getChatMessages(chatRoomId, 0);
+
+    // then
+    verify(chatRoomRepository, times(1)).findById(eq(chatRoomId));
+    verify(authService, times(1)).getLoginUserId();
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(loginUserId), eq(chatRoomId));
+    verify(chatMessageRepository, times(1))
+        .findAllByChatRoom(eq(chatRoom), eq(pageable));
+
+    assertThat(responseChatMessages).isNotNull();
+    assertThat(responseChatMessages.getSize()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 내역 조회 - 실패 (존재하지 않는 채팅방)")
+  void testGetChatMessages_Fail_ChatRoomNotFound() {
+    // given
+    Long chatRoomId = 1L;
+
+    given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.empty());
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatMessageService.getChatMessages(chatRoomId, 0));
+
+    // then
+    verify(chatRoomRepository, times(1)).findById(eq(chatRoomId));
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND);
+    assertThat(customException.getErrorMessage()).isEqualTo("채팅방을 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("채팅 메시지 내역 조회 - 실패 (해당 스터디 참여자가 아닌 경우)")
+  void testGetChatMessages_Fail_DoesNotStudentOfStudy() {
+    // given
+    Long chatRoomId = 1L;
+    Long loginUserId = 1L;
+
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+
+    given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.of(chatRoom));
+    given(authService.getLoginUserId()).willReturn(1L);
+    given(studentRepository.existsByUserIdAndStudyId(eq(loginUserId), eq(chatRoomId)))
+        .willReturn(false);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatMessageService.getChatMessages(chatRoomId, 0));
+
+    // then
+    verify(chatRoomRepository, times(1)).findById(eq(chatRoomId));
+    verify(authService, times(1)).getLoginUserId();
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(loginUserId), eq(chatRoomId));
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.DOES_NOT_STUDENT_OF_STUDY);
+    assertThat(customException.getErrorMessage()).isEqualTo("해당 스터디 참가자가 아닙니다.");
+  }
+}

--- a/src/test/java/com/devonoff/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/devonoff/domain/chat/service/ChatRoomServiceTest.java
@@ -1,0 +1,173 @@
+package com.devonoff.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.devonoff.domain.chat.dto.ChatRoomDto;
+import com.devonoff.domain.chat.entity.ChatRoom;
+import com.devonoff.domain.chat.repository.ChatRoomRepository;
+import com.devonoff.domain.student.repository.StudentRepository;
+import com.devonoff.domain.study.entity.Study;
+import com.devonoff.domain.study.repository.StudyRepository;
+import com.devonoff.domain.user.service.AuthService;
+import com.devonoff.exception.CustomException;
+import com.devonoff.type.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+  @InjectMocks
+  private ChatRoomService chatRoomService;
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  private StudyRepository studyRepository;
+
+  @Mock
+  private StudentRepository studentRepository;
+
+  @Mock
+  private AuthService authService;
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 성공 (해당 스터디에 채팅방이 존재하지 않는 경우)")
+  void testGetOrCreateChatRoom_Success() {
+    // given
+    Long studyId = 1L;
+    Long userId = 1L;
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+
+    given(authService.getLoginUserId()).willReturn(1L);
+    given(studyRepository.findById(eq(studyId))).willReturn(Optional.of(study));
+    given(studentRepository.existsByUserIdAndStudyId(eq(userId), eq(studyId))).willReturn(true);
+    given(chatRoomRepository.findByStudyId(eq(studyId))).willReturn(Optional.empty());
+    given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(chatRoom);
+
+    // when
+    ChatRoomDto chatRoomDto = chatRoomService.getOrCreateChatRoom(studyId, userId);
+
+    // then
+    verify(authService, times(1)).getLoginUserId();
+    verify(studyRepository, times(1)).findById(eq(studyId));
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(userId), eq(studyId));
+    verify(chatRoomRepository, times(1)).findByStudyId(eq(studyId));
+    verify(chatRoomRepository, times(1)).save(any(ChatRoom.class));
+
+    assertThat(chatRoomDto.getChatRoomId()).isEqualTo(1L);
+    assertThat(chatRoomDto.getStudyId()).isEqualTo(1L);
+    assertThat(chatRoomDto.getStudyName()).isEqualTo("Test Study");
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 성공 (해당 스터디에 채팅방이 존재하는 경우)")
+  void testGetOrCreateChatRoom_Success_ExistsChatRoom() {
+    // given
+    Long studyId = 1L;
+    Long userId = 1L;
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
+
+    given(authService.getLoginUserId()).willReturn(1L);
+    given(studyRepository.findById(eq(studyId))).willReturn(Optional.of(study));
+    given(studentRepository.existsByUserIdAndStudyId(eq(userId), eq(studyId))).willReturn(true);
+    given(chatRoomRepository.findByStudyId(eq(studyId))).willReturn(Optional.of(chatRoom));
+
+    // when
+    ChatRoomDto chatRoomDto = chatRoomService.getOrCreateChatRoom(studyId, userId);
+
+    // then
+    verify(authService, times(1)).getLoginUserId();
+    verify(studyRepository, times(1)).findById(eq(studyId));
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(userId), eq(studyId));
+    verify(chatRoomRepository, times(1)).findByStudyId(eq(studyId));
+
+    assertThat(chatRoomDto.getChatRoomId()).isEqualTo(1L);
+    assertThat(chatRoomDto.getStudyId()).isEqualTo(1L);
+    assertThat(chatRoomDto.getStudyName()).isEqualTo("Test Study");
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 실패 (로그인한 유저와 불일치)")
+  void testGetOrCreateChatRoom_Fail_UnAuthorizedUser() {
+    // given
+    Long studyId = 1L;
+    Long userId = 1L;
+
+    given(authService.getLoginUserId()).willReturn(2L);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatRoomService.getOrCreateChatRoom(studyId, userId));
+
+    // then
+    verify(authService, times(1)).getLoginUserId();
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED_USER);
+    assertThat(customException.getErrorMessage()).isEqualTo("로그인 된 사용자와 일치하지 않습니다.");
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 실패 (존재하지 않는 스터디)")
+  void testGetOrCreateChatRoom_Fail_StudyNotFound() {
+    // given
+    Long studyId = 1L;
+    Long userId = 1L;
+
+    given(authService.getLoginUserId()).willReturn(1L);
+    given(studyRepository.findById(eq(studyId))).willReturn(Optional.empty());
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatRoomService.getOrCreateChatRoom(studyId, userId));
+
+    // then
+    verify(authService, times(1)).getLoginUserId();
+    verify(studyRepository, times(1)).findById(eq(studyId));
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.STUDY_NOT_FOUND);
+    assertThat(customException.getErrorMessage()).isEqualTo("스터디를 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 및 조회 - 실패 (해당 스터디 참여자가 아닌 경우)")
+  void testGetOrCreateChatRoom_Fail_DoesNotStudentOfStudy() {
+    // given
+    Long studyId = 1L;
+    Long userId = 1L;
+    Study study = Study.builder().id(1L).studyName("Test Study").build();
+
+    given(authService.getLoginUserId()).willReturn(1L);
+    given(studyRepository.findById(eq(studyId))).willReturn(Optional.of(study));
+    given(studentRepository.existsByUserIdAndStudyId(eq(userId), eq(studyId))).willReturn(false);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> chatRoomService.getOrCreateChatRoom(studyId, userId));
+
+    // then
+    verify(authService, times(1)).getLoginUserId();
+    verify(studyRepository, times(1)).findById(eq(studyId));
+    verify(studentRepository, times(1))
+        .existsByUserIdAndStudyId(eq(userId), eq(studyId));
+
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.DOES_NOT_STUDENT_OF_STUDY);
+    assertThat(customException.getErrorMessage()).isEqualTo("해당 스터디 참가자가 아닙니다.");
+  }
+}


### PR DESCRIPTION
### Pull Request

> ### 변경사항
>
> 🔖 **TO-BE**
> - 프론트엔드 로컬 주소 WebSocket Origin 허용
> - 채팅 메시지 응답값 sender -> user 로 통일
> - 채팅 메시지 내역 페이네이션 적용
> - ChatMessageRepository 메시지 내역 조회 메서드 수정
> - 채팅 테스트 코드 작성

> ### 테스트
>
> - [x] 테스트 코드
> - [x] API 테스트