### PR TITLE
회원탈퇴 기능에서 소셜, 일반 로그인 구분 및 비밀번호 변경 기능 수정 / 채팅 메시지 전송 api endpoint 수정

### DIFF
--- a/src/main/java/com/devonoff/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/devonoff/domain/chat/controller/ChatController.java
@@ -16,7 +16,7 @@ public class ChatController {
 
   private final ChatMessageService chatMessageService;
 
-  @MessageMapping("/chat/{chatRoomId}/sendMessage")
+  @MessageMapping("/chat/{chatRoomId}/send-messages")
   @SendTo("/topic/chat/{chatRoomId}")
   public ChatMessageDto sendMessage(
       @DestinationVariable Long chatRoomId,

--- a/src/main/java/com/devonoff/domain/user/controller/AuthController.java
+++ b/src/main/java/com/devonoff/domain/user/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.devonoff.domain.user.controller;
 
+import com.devonoff.domain.user.dto.UserDto;
 import com.devonoff.domain.user.dto.auth.CertificationRequest;
 import com.devonoff.domain.user.dto.auth.EmailRequest;
 import com.devonoff.domain.user.dto.auth.NickNameCheckRequest;
+import com.devonoff.domain.user.dto.auth.PasswordChangeRequest;
 import com.devonoff.domain.user.dto.auth.ReissueTokenRequest;
 import com.devonoff.domain.user.dto.auth.ReissueTokenResponse;
 import com.devonoff.domain.user.dto.auth.SignInRequest;
@@ -122,6 +124,22 @@ public class AuthController {
   @PostMapping("/sign-out")
   public ResponseEntity<Void> signOut() {
     authService.signOut();
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 비밀번호 변경
+   *
+   * @param userId
+   * @param passwordChangeRequest
+   * @return ResponseEntity<UserDto>
+   */
+  @PostMapping("/change-password/{userId}")
+  public ResponseEntity<UserDto> changePassword(
+      @PathVariable Long userId,
+      @RequestBody @Valid PasswordChangeRequest passwordChangeRequest
+  ) {
+    UserDto userDto = authService.changePassword(userId, passwordChangeRequest);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/devonoff/domain/user/controller/AuthController.java
+++ b/src/main/java/com/devonoff/domain/user/controller/AuthController.java
@@ -145,7 +145,7 @@ public class AuthController {
    */
   @PostMapping("/withdrawal")
   public ResponseEntity<Void> withdrawalUser(
-      @RequestBody @Valid WithdrawalRequest withdrawalRequest
+      @RequestBody(required = false) @Valid WithdrawalRequest withdrawalRequest
   ) {
     authService.withdrawalUser(withdrawalRequest);
     return ResponseEntity.ok().build();

--- a/src/main/java/com/devonoff/domain/user/dto/UserDto.java
+++ b/src/main/java/com/devonoff/domain/user/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.devonoff.domain.user.dto;
 
 import com.devonoff.domain.user.entity.User;
+import com.devonoff.type.LoginType;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +21,7 @@ public class UserDto {
   private String email;
   private String profileImageUrl;
   private Boolean isActive;
+  private LoginType signinType;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
@@ -30,6 +32,7 @@ public class UserDto {
         .email(user.getEmail())
         .profileImageUrl(user.getProfileImage())
         .isActive(user.getIsActive())
+        .signinType(user.getLoginType())
         .createdAt(user.getCreatedAt())
         .updatedAt(user.getUpdatedAt())
         .build();

--- a/src/main/java/com/devonoff/domain/user/dto/auth/PasswordChangeRequest.java
+++ b/src/main/java/com/devonoff/domain/user/dto/auth/PasswordChangeRequest.java
@@ -1,0 +1,30 @@
+package com.devonoff.domain.user.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PasswordChangeRequest {
+
+  @NotBlank
+  @Pattern(
+      regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,}$",
+      message = "비밀번호는 최소 8자리 이상이며, 하나 이상의 영문자, 숫자, 특수문자를 포함해야 합니다."
+  )
+  private String currentPassword;
+
+  @NotBlank
+  @Pattern(
+      regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,}$",
+      message = "비밀번호는 최소 8자리 이상이며, 하나 이상의 영문자, 숫자, 특수문자를 포함해야 합니다."
+  )
+  private String newPassword;
+
+}

--- a/src/main/java/com/devonoff/domain/user/service/AuthService.java
+++ b/src/main/java/com/devonoff/domain/user/service/AuthService.java
@@ -217,6 +217,8 @@ public class AuthService {
 
   /**
    * 회원 탈퇴
+   *
+   * @param withdrawalRequest
    */
   @Transactional
   public void withdrawalUser(WithdrawalRequest withdrawalRequest) {
@@ -224,9 +226,15 @@ public class AuthService {
     User user = userRepository.findById(loginUserId)
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-    boolean isMatch = passwordEncoder.matches(withdrawalRequest.getPassword(), user.getPassword());
-    if (!isMatch) {
-      throw new CustomException(ErrorCode.INVALID_PASSWORD);
+    if (user.getLoginType() == LoginType.GENERAL) {
+      if (withdrawalRequest == null) {
+        throw new CustomException(ErrorCode.PASSWORD_IS_NULL);
+      }
+
+      boolean isMatch = passwordEncoder.matches(withdrawalRequest.getPassword(), user.getPassword());
+      if (!isMatch) {
+        throw new CustomException(ErrorCode.INVALID_PASSWORD);
+      }
     }
 
     // 탈퇴한 사용자가 속한 모든 스터디에서 스터디 참가자 제거
@@ -288,6 +296,5 @@ public class AuthService {
     UserDetails userDetails = (UserDetails) authentication.getPrincipal();
     return Long.parseLong(userDetails.getUsername());
   }
-
 
 }

--- a/src/main/java/com/devonoff/type/ErrorCode.java
+++ b/src/main/java/com/devonoff/type/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
   NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST.value(), "이미 사용 중인 닉네임입니다."), // 400
   INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 잘못되었습니다."), // 401
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 잘못되었습니다."), // 400
+  PASSWORD_IS_NULL(HttpStatus.BAD_REQUEST.value(), "비밀번호를 입력해주세요."), // 400
   SOCIAL_LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), "소셜 로그인에 실패했습니다."), // 401
   ACCOUNT_PENDING_DELETION(HttpStatus.FORBIDDEN.value(), "해당 계정은 탈퇴 예정 상태입니다."), // 403 -> 필요한가?
   EMAIL_CERTIFICATION_FAILED(HttpStatus.BAD_REQUEST.value(),

--- a/src/test/java/com/devonoff/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/devonoff/domain/user/controller/AuthControllerTest.java
@@ -10,9 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.devonoff.config.SecurityConfig;
+import com.devonoff.domain.user.dto.UserDto;
 import com.devonoff.domain.user.dto.auth.CertificationRequest;
 import com.devonoff.domain.user.dto.auth.EmailRequest;
 import com.devonoff.domain.user.dto.auth.NickNameCheckRequest;
+import com.devonoff.domain.user.dto.auth.PasswordChangeRequest;
 import com.devonoff.domain.user.dto.auth.ReissueTokenRequest;
 import com.devonoff.domain.user.dto.auth.ReissueTokenResponse;
 import com.devonoff.domain.user.dto.auth.SignInRequest;
@@ -277,6 +279,68 @@ class AuthControllerTest {
     // when, then
     mockMvc.perform(post("/api/auth/sign-out"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 - 성공")
+  void testChangePassword_Success() throws Exception {
+    // given
+    Long userId = 1L;
+    PasswordChangeRequest passwordChangeRequest = PasswordChangeRequest.builder()
+        .currentPassword("currentPassword1234!!!")
+        .newPassword("newPassword1234!!!")
+        .build();
+
+    UserDto userDto = UserDto.builder().id(1L).build();
+
+    given(authService.changePassword(userId, passwordChangeRequest)).willReturn(userDto);
+
+    // when , then
+    mockMvc.perform(post("/api/auth/change-password/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(passwordChangeRequest)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 - 실패 (유효성 검증 실패)")
+  void testChangePassword_Fail() throws Exception {
+    // given
+    Long userId = 1L;
+    PasswordChangeRequest passwordChangeRequest = PasswordChangeRequest.builder()
+        .newPassword("newPassword1234!!!")
+        .build();
+
+    UserDto userDto = UserDto.builder().id(1L).build();
+
+    given(authService.changePassword(userId, passwordChangeRequest)).willReturn(userDto);
+
+    // when , then
+    mockMvc.perform(post("/api/auth/change-password/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(passwordChangeRequest)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경 - 실패 (비밀번호 패턴 불일치)")
+  void testChangePassword_Fail_PatternUnMatched() throws Exception {
+    // given
+    Long userId = 1L;
+    PasswordChangeRequest passwordChangeRequest = PasswordChangeRequest.builder()
+        .currentPassword("currentPassword")
+        .newPassword("newPassword")
+        .build();
+
+    UserDto userDto = UserDto.builder().id(1L).build();
+
+    given(authService.changePassword(userId, passwordChangeRequest)).willReturn(userDto);
+
+    // when , then
+    mockMvc.perform(post("/api/auth/change-password/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(passwordChangeRequest)))
+        .andExpect(status().isBadRequest());
   }
 
   @Test


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 🔖 **TO-BE**
> - 사용자 정보 응답시 로그인 타입 추가로 응답
> - 회원 탈퇴시 일반 이메일 로그인과 소셜 로그인 분리 및 테스트 코드 작성
> - 비밀번호 기능 추가 및 테스트 코드 작성
> - 채팅 메시지 구독 및 전송 api endpoint 수정

> ### 테스트
>
> - [x] 테스트 코드
> - [x] API 테스트