### PR TITLE
fix: 자동 취소 및 삭제 로직 수정 및 관련 엔티티 연관관계 개선

### DIFF
--- a/src/main/java/com/devonoff/config/BatchConfig.java
+++ b/src/main/java/com/devonoff/config/BatchConfig.java
@@ -1,10 +1,7 @@
 package com.devonoff.config;
 
-import com.devonoff.domain.studyPost.entity.StudyComment;
 import com.devonoff.domain.studyPost.entity.StudyPost;
-import com.devonoff.domain.studyPost.repository.StudyCommentRepository;
 import com.devonoff.domain.studyPost.repository.StudyPostRepository;
-import com.devonoff.domain.studyPost.repository.StudyReplyRepository;
 import com.devonoff.domain.studyPost.service.StudyPostService;
 import com.devonoff.type.StudyPostStatus;
 import com.devonoff.util.TimeProvider;
@@ -27,8 +24,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 public class BatchConfig {
 
   private final StudyPostRepository studyPostRepository;
-  private final StudyCommentRepository studyCommentRepository;
-  private final StudyReplyRepository studyReplyRepository;
   private final StudyPostService studyPostService;
   private final TimeProvider timeProvider;
 
@@ -53,24 +48,12 @@ public class BatchConfig {
     return (contribution, chunkContext) -> {
       LocalDateTime oneWeekAgo = timeProvider.now().minusDays(7);
 
-      // 모집 기한이 지난 스터디 모집글을 CANCELED 로 변경(배치작업으로 자동 취소)
+      // 모집 기한이 지난 스터디 모집글을 CANCELED 로 변경
       studyPostService.cancelStudyPostIfExpired();
 
+      // 취소 상태에서 일주일이 지난 스터디 모집글 삭제
       List<StudyPost> studyPostsToDelete = studyPostRepository.findAllByStatusAndUpdatedAtBefore(
           StudyPostStatus.CANCELED, oneWeekAgo);
-
-      // 댓글 / 대댓글 삭제
-      for (StudyPost studyPost : studyPostsToDelete) {
-        List<StudyComment> comments = studyCommentRepository.findAllByStudyPost(studyPost);
-
-        for (StudyComment comment : comments) {
-          studyReplyRepository.deleteAllByComment(comment);
-        }
-
-        studyCommentRepository.deleteAllByStudyPost(studyPost);
-      }
-
-      // 취소 상태에서 일주일이 지난 스터디 모집글 삭제
       studyPostRepository.deleteAll(studyPostsToDelete);
 
       return RepeatStatus.FINISHED;

--- a/src/main/java/com/devonoff/config/BatchManualExecutor.java
+++ b/src/main/java/com/devonoff/config/BatchManualExecutor.java
@@ -1,0 +1,23 @@
+package com.devonoff.config;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+// BatchManualExecutor 는 애플리케이션 시작 시 배치 작업을 실행하기 위한 클래스입니다.
+// 현재는 필요하지 않아 주석 처리했지만, 테스트나 수동 실행이 필요한 경우 사용할 수 있습니다.
+//@Component
+public class BatchManualExecutor {
+
+  private final BatchScheduler batchScheduler;
+
+  public BatchManualExecutor(BatchScheduler batchScheduler) {
+    this.batchScheduler = batchScheduler;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void executeBatchOnStartup() {
+    batchScheduler.runDeleteOldStudyPostsJob();
+    System.out.println("Batch job executed on application startup.");
+  }
+}

--- a/src/main/java/com/devonoff/domain/study/entity/Study.java
+++ b/src/main/java/com/devonoff/domain/study/entity/Study.java
@@ -79,7 +79,7 @@ public class Study extends BaseTimeEntity {
   @Column(nullable = false)
   private Integer totalParticipants; // 스터디 총 인원 (스터디장 포함)
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "study_post_id", nullable = false)
   private StudyPost studyPost; // 스터디 모집글
 

--- a/src/main/java/com/devonoff/domain/studyPost/entity/StudyComment.java
+++ b/src/main/java/com/devonoff/domain/studyPost/entity/StudyComment.java
@@ -3,6 +3,7 @@ package com.devonoff.domain.studyPost.entity;
 
 import com.devonoff.common.entity.BaseTimeEntity;
 import com.devonoff.domain.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -31,7 +32,7 @@ public class StudyComment extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "post_id", nullable = false)
   private StudyPost studyPost;
 
@@ -41,10 +42,10 @@ public class StudyComment extends BaseTimeEntity {
   @Column(nullable = false)
   private String content;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
-  @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<StudyReply> replies;
 }

--- a/src/main/java/com/devonoff/domain/studyPost/entity/StudyPost.java
+++ b/src/main/java/com/devonoff/domain/studyPost/entity/StudyPost.java
@@ -1,7 +1,9 @@
 package com.devonoff.domain.studyPost.entity;
 
 import com.devonoff.common.entity.BaseTimeEntity;
+import com.devonoff.domain.study.entity.Study;
 import com.devonoff.domain.studyPost.dto.StudyPostUpdateRequest;
+import com.devonoff.domain.studySignup.entity.StudySignup;
 import com.devonoff.domain.user.entity.User;
 import com.devonoff.exception.CustomException;
 import com.devonoff.type.ErrorCode;
@@ -10,6 +12,7 @@ import com.devonoff.type.StudyMeetingType;
 import com.devonoff.type.StudyPostStatus;
 import com.devonoff.type.StudySubject;
 import com.devonoff.util.DayTypeUtils;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -20,8 +23,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -104,6 +109,12 @@ public class StudyPost extends BaseTimeEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user; // 작성자
+
+  @OneToMany(mappedBy = "studyPost", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<StudySignup> signups;
+
+  @OneToMany(mappedBy = "studyPost", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<Study> studies;
 
   public void cancelRecruitment() {
     this.status = StudyPostStatus.CANCELED;

--- a/src/main/java/com/devonoff/domain/studyPost/entity/StudyReply.java
+++ b/src/main/java/com/devonoff/domain/studyPost/entity/StudyReply.java
@@ -35,7 +35,7 @@ public class StudyReply extends BaseTimeEntity {
   @Column(nullable = false)
   private String content;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 


### PR DESCRIPTION
### Pull Request

> ### 변경사항

> 📌 **AS-IS**

- 모집 기한이 지난 모집글이 자동으로 취소되지 않거나 삭제되지 않는 문제
- StudyComment 및 StudyReply 엔티티에서 CascadeType.REMOVE 미사용으로 삭제 시 연관 엔티티 처리 누락
- BatchConfig에서 댓글 및 대댓글 삭제 로직 중복

> 🔖 **TO-BE**

- 자동 취소 및 삭제 로직 수정 및 관련 엔티티 연관관계 개선
   - 모집 기한이 지난 모집글 자동 취소 및 삭제 로직 수정
   - StudyComment 및 StudyReply 엔티티에 CascadeType.REMOVE 추가
   - BatchConfig에서 불필요한 댓글/대댓글 삭제 코드 제거
   - Study 엔티티와 StudyPost 간의 연관관계 추가

> ### 테스트
>
> - [x] API 테스트