### PR TITLE
채팅시 스터디 장 표시 및 이미지 업로드시 최대 크기 제한 및 에러처리

### DIFF
--- a/src/main/java/com/devonoff/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/devonoff/domain/chat/dto/ChatRoomDto.java
@@ -15,12 +15,14 @@ public class ChatRoomDto {
   private Long chatRoomId;
   private Long studyId;
   private String studyName;
+  private Long leaderId;
 
-  public static ChatRoomDto fromEntity(ChatRoom chatRoom) {
+  public static ChatRoomDto fromEntity(ChatRoom chatRoom, Long leaderId) {
     return ChatRoomDto.builder()
         .chatRoomId(chatRoom.getId())
         .studyId(chatRoom.getStudy().getId())
         .studyName(chatRoom.getStudyName())
+        .leaderId(leaderId)
         .build();
   }
 

--- a/src/main/java/com/devonoff/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/devonoff/domain/chat/service/ChatRoomService.java
@@ -51,6 +51,6 @@ public class ChatRoomService {
                 .build())
         );
 
-    return ChatRoomDto.fromEntity(chatRoom);
+    return ChatRoomDto.fromEntity(chatRoom, study.getStudyLeader().getId());
   }
 }

--- a/src/main/java/com/devonoff/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devonoff/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.devonoff.exception;
 
 import static com.devonoff.type.ErrorCode.BAD_REQUEST;
+import static com.devonoff.type.ErrorCode.EXCEED_FILE_SIZE;
 import static com.devonoff.type.ErrorCode.INTERNAL_SERVER_ERROR;
 
 import com.devonoff.common.dto.ErrorResponse;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 
 @Slf4j
@@ -47,6 +49,17 @@ public class GlobalExceptionHandler {
             ErrorResponse.builder()
                 .errorCode(INTERNAL_SERVER_ERROR)
                 .errorMessage(INTERNAL_SERVER_ERROR.getDescription())
+                .build()
+        );
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<ErrorResponse> handleMaxSizeException(MaxUploadSizeExceededException exc) {
+    return ResponseEntity.status(EXCEED_FILE_SIZE.getStatus())
+        .body(
+            ErrorResponse.builder()
+                .errorCode(EXCEED_FILE_SIZE)
+                .errorMessage(EXCEED_FILE_SIZE.getDescription())
                 .build()
         );
   }

--- a/src/main/java/com/devonoff/type/ErrorCode.java
+++ b/src/main/java/com/devonoff/type/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
   // 회원가입 및 로그인
   EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST.value(), "이미 사용 중인 이메일입니다."), // 400
   NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST.value(), "이미 사용 중인 닉네임입니다."), // 400
-  INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 잘못되었습니다."), // 401
+  INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST.value(), "이메일 또는 비밀번호가 잘못되었습니다."), // 400
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 잘못되었습니다."), // 400
   PASSWORD_IS_NULL(HttpStatus.BAD_REQUEST.value(), "비밀번호를 입력해주세요."), // 400
   SAME_PASSWORD(HttpStatus.BAD_REQUEST.value(), "기존 비밀번호와 동일합니다."), // 400
@@ -29,6 +29,8 @@ public enum ErrorCode {
   PROFILE_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(),
       "프로필 이미지를 업로드하는 데 실패했습니다."), // 500
   UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED.value(), "로그인 된 사용자와 일치하지 않습니다."),
+  // 파일 업로드 관련
+  EXCEED_FILE_SIZE(HttpStatus.BAD_REQUEST.value(), "파일 크기가 제한을 초과했습니다. 최대 5MB까지 업로드 가능합니다."),
   // 스터디 관련
   STUDY_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "스터디 모집글을 찾을 수 없습니다."), // 404
   STUDY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "스터디를 찾을 수 없습니다."), // 404

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,6 +74,10 @@ spring:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             redirect-uri: ${NAVER_REDIRECT_URI}
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
 
 cloud:
   aws:

--- a/src/test/java/com/devonoff/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/devonoff/domain/chat/service/ChatRoomServiceTest.java
@@ -14,6 +14,7 @@ import com.devonoff.domain.chat.repository.ChatRoomRepository;
 import com.devonoff.domain.student.repository.StudentRepository;
 import com.devonoff.domain.study.entity.Study;
 import com.devonoff.domain.study.repository.StudyRepository;
+import com.devonoff.domain.user.entity.User;
 import com.devonoff.domain.user.service.AuthService;
 import com.devonoff.exception.CustomException;
 import com.devonoff.type.ErrorCode;
@@ -49,7 +50,8 @@ class ChatRoomServiceTest {
     // given
     Long studyId = 1L;
     Long userId = 1L;
-    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    User user = User.builder().id(2L).build();
+    Study study = Study.builder().id(1L).studyName("Test Study").studyLeader(user).build();
     ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
 
     given(authService.getLoginUserId()).willReturn(1L);
@@ -72,6 +74,7 @@ class ChatRoomServiceTest {
     assertThat(chatRoomDto.getChatRoomId()).isEqualTo(1L);
     assertThat(chatRoomDto.getStudyId()).isEqualTo(1L);
     assertThat(chatRoomDto.getStudyName()).isEqualTo("Test Study");
+    assertThat(chatRoomDto.getLeaderId()).isEqualTo(2L);
   }
 
   @Test
@@ -80,7 +83,8 @@ class ChatRoomServiceTest {
     // given
     Long studyId = 1L;
     Long userId = 1L;
-    Study study = Study.builder().id(1L).studyName("Test Study").build();
+    User user = User.builder().id(2L).build();
+    Study study = Study.builder().id(1L).studyName("Test Study").studyLeader(user).build();
     ChatRoom chatRoom = ChatRoom.builder().id(1L).studyName("Test Study").study(study).build();
 
     given(authService.getLoginUserId()).willReturn(1L);
@@ -101,6 +105,7 @@ class ChatRoomServiceTest {
     assertThat(chatRoomDto.getChatRoomId()).isEqualTo(1L);
     assertThat(chatRoomDto.getStudyId()).isEqualTo(1L);
     assertThat(chatRoomDto.getStudyName()).isEqualTo("Test Study");
+    assertThat(chatRoomDto.getLeaderId()).isEqualTo(2L);
   }
 
   @Test


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> - 기존 이미지 업로드시 최대 사이즈 크기를 설정하지 않아 500 에러가 발생
> - 채팅방의 메시지 내역에서 따로 스터디 장을 표시해주는 기능이 없음
>
> 🔖 **TO-BE**
> - 이미지 업로드시 최대사이즈 크기 설정 및 에러처리
> - 채팅방의 메시지 내역에서 스터디 장 표시를 위해 채팅방 입장시 스터디 장 정보 응답

> ### 테스트
>
> - [x] 테스트 코드
> - [x] API 테스트