### PR TITLE
jvm 시간대가 한국시간으로 설정 됨에 따라 채팅 메시지 내역 표시 시간 dto 수정

### DIFF
--- a/src/main/java/com/devonoff/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/devonoff/domain/chat/dto/ChatMessageDto.java
@@ -3,8 +3,6 @@ package com.devonoff.domain.chat.dto;
 import com.devonoff.domain.chat.entity.ChatMessage;
 import com.devonoff.domain.user.dto.UserDto;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,15 +24,8 @@ public class ChatMessageDto {
         .id(chatMessage.getId())
         .user(UserDto.fromEntity(chatMessage.getSender()))
         .content(chatMessage.getContent())
-        .createdAt(getKoreaTime(chatMessage.getCreatedAt()))
+        .createdAt(chatMessage.getCreatedAt())
         .build();
-  }
-
-  // UTC -> Asia/Seoul 로 시간대 변경
-  private static LocalDateTime getKoreaTime(LocalDateTime createdAt) {
-    ZonedDateTime utcTime = createdAt.atZone(ZoneId.of("UTC"));
-    ZonedDateTime koreaTime = utcTime.withZoneSameInstant(ZoneId.of("Asia/Seoul"));
-    return koreaTime.toLocalDateTime();
   }
 
 }


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> - ChatMessageDto 에서 기존 UTC 시간대의 채팅 메시지 내역의 시간을 한국시간으로 변경하여 하여 응답
>
> 🔖 **TO-BE**
> - ChatMessageDto 에서 jvm 시간대가 한국시간으로 설정 됨에 따라 채팅 메시지 내역 표시 시간을 한국시간으로 변경하는 로직 삭제
>
> ### 테스트
>
> - [x] 테스트 코드
> - [x] API 테스트